### PR TITLE
Add automatic update checks for PSPA Membership System

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: PSPA Membership System
+ * Description: Membership system for PSPA.
+ * Version: 0.0.1
+ * Author: PSPA
+ *
+ * @package PSPA\MembershipSystem
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Load the plugin update checker library.
+require plugin_dir_path( __FILE__ ) . 'plugin-update-checker/plugin-update-checker.php';
+
+use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
+
+// Initialize the update checker.
+$pspa_update_checker = PucFactory::buildUpdateChecker(
+    'https://github.com/PSPA/pspa-membership-system/',
+    __FILE__,
+    'pspa-membership-system'
+);
+
+// Optional: set the branch to check for updates.
+$pspa_update_checker->setBranch( 'main' );
+


### PR DESCRIPTION
## Summary
- integrate plugin-update-checker to enable automatic updates
- set initial plugin version to 0.0.1

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc206fb5288327a8a9248ae2827487