### PR TITLE
Document ACF fields and add plugin readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,69 @@ Dependencies:
 - [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/)
 - [WooCommerce](https://woocommerce.com/)
 
+## ACF Field Reference
+
+The plugin registers a **Graduate Profile** field group in Advanced Custom Fields. The field definitions are exported to `acf-export-2025-09-06-with-profile.json` and include the following fields:
+
+### Βασικά στοιχεία
+- **Επώνυμο** (`gn_surname`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Επώνυμο** (`gn_show_surname`, true_false)
+- **Όνομα** (`gn_first_name`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Όνομα** (`gn_show_first_name`, true_false)
+- **Πατρώνυμο** (`gn_father_name`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Πατρώνυμο** (`gn_show_father_name`, true_false)
+- **Αποφοίτηση (Έτος)** (`gn_graduation_year`, number)
+- **Εμφάνιση στο δημόσιο προφίλ: Αποφοίτηση (Έτος)** (`gn_show_graduation_year`, true_false)
+- **Α (ΠΟΒΙΩΣΑΣ) – Απεβίωσε** (`gn_deceased`, true_false)
+- **Εμφάνιση στο δημόσιο προφίλ: Α (ΠΟΒΙΩΣΑΣ) – Απεβίωσε** (`gn_show_deceased`, true_false)
+- **ΣΧΟΛΙΑ** (`gn_notes`, textarea)
+- **Εμφάνιση στο δημόσιο προφίλ: ΣΧΟΛΙΑ** (`gn_show_notes`, true_false)
+- **Φωτογραφία προφίλ** (`gn_profile_picture`, image)
+- **Εμφάνιση στο δημόσιο προφίλ: Φωτογραφία προφίλ** (`gn_show_profile_picture`, true_false)
+
+### Επικοινωνία
+- **e-Mail** (`gn_email`, email)
+- **Εμφάνιση στο δημόσιο προφίλ: e-Mail** (`gn_show_email`, true_false)
+- **Κινητό** (`gn_mobile`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Κινητό** (`gn_show_mobile`, true_false)
+- **Τηλ. Εργασίας** (`gn_work_phone`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Τηλ. Εργασίας** (`gn_show_work_phone`, true_false)
+- **Εργασίας 2** (`gn_work_phone_2`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Εργασίας 2** (`gn_show_work_phone_2`, true_false)
+- **Τηλ. Κατοικίας** (`gn_home_phone`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Τηλ. Κατοικίας** (`gn_show_home_phone`, true_false)
+- **Κατοικίας 2** (`gn_home_phone_2`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Κατοικίας 2** (`gn_show_home_phone_2`, true_false)
+- **FAX** (`gn_fax`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: FAX** (`gn_show_fax`, true_false)
+
+### Διεύθυνση
+- **Οδός/Αριθμός** (`gn_street_address`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Οδός/Αριθμός** (`gn_show_street_address`, true_false)
+- **Τ.Κ.** (`gn_postal_code`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Τ.Κ.** (`gn_show_postal_code`, true_false)
+- **Περιοχή** (`gn_area`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Περιοχή** (`gn_show_area`, true_false)
+- **Πόλη** (`gn_city`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Πόλη** (`gn_show_city`, true_false)
+- **Κράτος** (`gn_country`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Κράτος** (`gn_show_country`, true_false)
+
+### Σπουδές
+- **ΣΠΟΥΔΕΣ Πτυχίο** (`gn_degree`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: ΣΠΟΥΔΕΣ Πτυχίο** (`gn_show_degree`, true_false)
+- **ΣΠΟΥΔΕΣ ΑΕΙ (Ίδρυμα)** (`gn_university`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: ΣΠΟΥΔΕΣ ΑΕΙ (Ίδρυμα)** (`gn_show_university`, true_false)
+- **Ειδικότητα** (`gn_specialization`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Ειδικότητα** (`gn_show_specialization`, true_false)
+
+### Εργασία
+- **Επάγγελμα** (`gn_profession`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Επάγγελμα** (`gn_show_profession`, true_false)
+- **Τίτλος** (`gn_job_title`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Τίτλος** (`gn_show_job_title`, true_false)
+- **Θέση-Εταιρεία** (`gn_position_company`, text)
+- **Εμφάνιση στο δημόσιο προφίλ: Θέση-Εταιρεία** (`gn_show_position_company`, true_false)
+
+### Ρυθμίσεις ορατότητας
+- **Λειτουργία ορατότητας** (`gn_visibility_mode`, radio)

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,30 @@
+=== PSPA Membership System ===
+Contributors: orionaselite
+Tags: membership, woocommerce, acf, profile
+Requires at least: 6.0
+Tested up to: 6.5
+Requires PHP: 7.4
+Stable tag: 0.0.1
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+This plugin powers the PSPA membership system and integrates with WooCommerce and Advanced Custom Fields (ACF) Pro.
+
+== Installation ==
+1. Upload `pspa-membership-system` to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. Ensure that ACF Pro and WooCommerce are installed and activated.
+
+== Frequently Asked Questions ==
+
+= What dependencies are required? =
+The plugin requires Advanced Custom Fields Pro and WooCommerce.
+
+== Changelog ==
+= 0.0.1 =
+* Initial release.
+
+== Upgrade Notice ==
+= 0.0.1 =
+Initial release.


### PR DESCRIPTION
## Summary
- document ACF field group used for the graduate profile
- add standard WordPress readme.txt

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc2439a9a08327bc7c8a6c7613ec5d