### PR TITLE
docs: document custom user roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This plugin powers the PSPA membership system and integrates with WooCommerce and Advanced Custom Fields (ACF) Pro.
 
+## Custom User Roles
+
+The plugin registers two custom user roles:
+
+- **Professional Catalogue** (`professionalcatalogue`)
+- **System Admin** (`system-admin`)
+
 ## Graduate Profile Dashboard
 
 The `Graduate Profile Dashboard` provides a single-page front-end form for graduates to manage their profile data. It is available under the WooCommerce "My Account" area via the `graduate-profile` endpoint.

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,12 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 == Description ==
 This plugin powers the PSPA membership system and integrates with WooCommerce and Advanced Custom Fields (ACF) Pro.
 
+== Custom User Roles ==
+The plugin registers two custom user roles:
+
+* Professional Catalogue (`professionalcatalogue`)
+* System Admin (`system-admin`)
+
 == Installation ==
 1. Upload `pspa-membership-system` to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.


### PR DESCRIPTION
## Summary
- document custom Professional Catalogue and System Admin user roles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc256de8f08327afb969e05509f714