### PR TITLE
Add required plugin dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dependencies:
 
 - [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/)
 - [WooCommerce](https://woocommerce.com/)
+- [Advanced Access Manager](https://wordpress.org/plugins/advanced-access-manager/)
 
 ## ACF Field Reference
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -14,6 +14,49 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Ensure required plugins are active.
+ */
+function pspa_ms_check_dependencies() {
+    if ( ! is_admin() ) {
+        return;
+    }
+
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+    $required_plugins = array(
+        'advanced-custom-fields-pro/acf.php' => 'Advanced Custom Fields Pro',
+        'woocommerce/woocommerce.php'        => 'WooCommerce',
+        'advanced-access-manager/aam.php'    => 'Advanced Access Manager',
+    );
+
+    $missing_plugins = array();
+
+    foreach ( $required_plugins as $file => $name ) {
+        if ( ! is_plugin_active( $file ) ) {
+            $missing_plugins[] = $name;
+        }
+    }
+
+    if ( ! empty( $missing_plugins ) ) {
+        add_action(
+            'admin_notices',
+            static function () use ( $missing_plugins ) {
+                echo '<div class="notice notice-error"><p>';
+                printf(
+                    'PSPA Membership System requires the following plugins to be active: %s.',
+                    esc_html( implode( ', ', $missing_plugins ) )
+                );
+                echo '</p></div>';
+            }
+        );
+
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+    }
+}
+
+pspa_ms_check_dependencies();
+
 // Load the plugin update checker library.
 require plugin_dir_path( __FILE__ ) . 'plugin-update-checker/plugin-update-checker.php';
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,12 +14,12 @@ This plugin powers the PSPA membership system and integrates with WooCommerce an
 == Installation ==
 1. Upload `pspa-membership-system` to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. Ensure that ACF Pro and WooCommerce are installed and activated.
+3. Ensure that ACF Pro, WooCommerce, and Advanced Access Manager are installed and activated.
 
 == Frequently Asked Questions ==
 
 = What dependencies are required? =
-The plugin requires Advanced Custom Fields Pro and WooCommerce.
+The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
 = 0.0.1 =


### PR DESCRIPTION
## Summary
- ensure PSPA Membership System only runs when Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager are active
- document Advanced Access Manager as a required dependency

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc2641ef488327bbcbbbd3dc69e375