### PR TITLE
Add graduate profile WooCommerce endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The plugin registers two custom user roles:
 
 ## Graduate Profile Dashboard
 
-The `Graduate Profile Dashboard` provides a single-page front-end form for graduates to manage their profile data. It is available under the WooCommerce "My Account" area via the `graduate-profile` endpoint.
+The `Graduate Profile Dashboard` provides a single-page front-end form for graduates to manage their profile data. It is available under the WooCommerce "My Account" area via the `graduate-profile` endpoint, labeled "Προφίλ Απόφοιτου".
 
 Key features:
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.1
+ * Version: 0.0.2
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -71,4 +71,106 @@ $pspa_update_checker = PucFactory::buildUpdateChecker(
 
 // Optional: set the branch to check for updates.
 $pspa_update_checker->setBranch( 'main' );
+
+/**
+ * Register the Graduate Profile endpoint.
+ */
+function pspa_ms_register_graduate_profile_endpoint() {
+    add_rewrite_endpoint( 'graduate-profile', EP_ROOT | EP_PAGES );
+}
+add_action( 'init', 'pspa_ms_register_graduate_profile_endpoint' );
+
+/**
+ * Add query var for the Graduate Profile endpoint.
+ *
+ * @param array $vars Query vars.
+ * @return array
+ */
+function pspa_ms_graduate_profile_query_vars( $vars ) {
+    $vars[] = 'graduate-profile';
+    return $vars;
+}
+add_filter( 'query_vars', 'pspa_ms_graduate_profile_query_vars' );
+
+/**
+ * Add Graduate Profile item to the My Account menu.
+ *
+ * @param array $items Menu items.
+ * @return array
+ */
+function pspa_ms_add_graduate_profile_link( $items ) {
+    $items['graduate-profile'] = __( 'Προφίλ Απόφοιτου', 'pspa-membership-system' );
+    return $items;
+}
+add_filter( 'woocommerce_account_menu_items', 'pspa_ms_add_graduate_profile_link' );
+
+/**
+ * Render Graduate Profile endpoint content.
+ */
+function pspa_ms_graduate_profile_content() {
+    if ( ! is_user_logged_in() ) {
+        echo esc_html__( 'You need to be logged in to edit your profile.', 'pspa-membership-system' );
+        return;
+    }
+
+    $user_id = get_current_user_id();
+    $user    = wp_get_current_user();
+
+    if (
+        'POST' === $_SERVER['REQUEST_METHOD'] &&
+        isset( $_POST['pspa_graduate_profile_nonce'] ) &&
+        wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['pspa_graduate_profile_nonce'] ) ), 'pspa_graduate_profile' )
+    ) {
+        $first_name = isset( $_POST['first_name'] ) ? sanitize_text_field( wp_unslash( $_POST['first_name'] ) ) : '';
+        $last_name  = isset( $_POST['last_name'] ) ? sanitize_text_field( wp_unslash( $_POST['last_name'] ) ) : '';
+        $email      = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+
+        wp_update_user(
+            array(
+                'ID'           => $user_id,
+                'first_name'   => $first_name,
+                'last_name'    => $last_name,
+                'user_email'   => $email,
+                'display_name' => trim( $first_name . ' ' . $last_name ),
+            )
+        );
+
+        wc_add_notice( __( 'Profile updated successfully.', 'pspa-membership-system' ) );
+        $user = wp_get_current_user();
+    }
+
+    ?>
+    <form class="woocommerce-EditAccountForm edit-account" method="post">
+        <p class="form-row form-row-first">
+            <label for="first_name"><?php esc_html_e( 'First name', 'pspa-membership-system' ); ?></label>
+            <input type="text" name="first_name" id="first_name" value="<?php echo esc_attr( $user->first_name ); ?>" />
+        </p>
+        <p class="form-row form-row-last">
+            <label for="last_name"><?php esc_html_e( 'Last name', 'pspa-membership-system' ); ?></label>
+            <input type="text" name="last_name" id="last_name" value="<?php echo esc_attr( $user->last_name ); ?>" />
+        </p>
+        <p class="form-row form-row-wide">
+            <label for="email"><?php esc_html_e( 'Email address', 'pspa-membership-system' ); ?></label>
+            <input type="email" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
+        </p>
+        <?php wp_nonce_field( 'pspa_graduate_profile', 'pspa_graduate_profile_nonce' ); ?>
+        <p>
+            <button type="submit" class="woocommerce-Button button">
+                <?php esc_html_e( 'Save changes', 'pspa-membership-system' ); ?>
+            </button>
+        </p>
+    </form>
+    <?php
+}
+add_action( 'woocommerce_account_graduate-profile_endpoint', 'pspa_ms_graduate_profile_content' );
+
+/**
+ * Flush rewrite rules on activation and deactivation.
+ */
+function pspa_ms_flush_rewrite_rules() {
+    pspa_ms_register_graduate_profile_endpoint();
+    flush_rewrite_rules();
+}
+register_activation_hook( __FILE__, 'pspa_ms_flush_rewrite_rules' );
+register_deactivation_hook( __FILE__, 'flush_rewrite_rules' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.1
+Stable tag: 0.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,9 +28,13 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.2 =
+* Added "Προφίλ Απόφοιτου" WooCommerce endpoint for graduates to edit their personal details.
 = 0.0.1 =
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.2 =
+Adds a WooCommerce endpoint for graduates to update their profile.
 = 0.0.1 =
 Initial release.


### PR DESCRIPTION
## Summary
- add “Προφίλ Απόφοιτου” endpoint in WooCommerce so graduates can update their profile details
- document graduate profile endpoint and bump plugin version to 0.0.2

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc2ae73d608327908bacd66b80a13d