### PR TITLE
Add admin user search, login shortcode, and role-based redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Dependencies:
 - [WooCommerce](https://woocommerce.com/)
 - [Advanced Access Manager](https://wordpress.org/plugins/advanced-access-manager/)
 
+## Administrator Tools
+
+System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, email and password controls.
+
+## Login by Details
+
+The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard.
+
+## Role-based Redirection
+
+Graduates and System Admins are redirected to the `Προφίλ Απόφοιτου` dashboard after login and are prevented from accessing the WordPress admin area.
+
 ## ACF Field Reference
 
 The plugin registers a **Graduate Profile** field group in Advanced Custom Fields. The field definitions are exported to `acf-export-2025-09-06-with-profile.json` and include the following fields:

--- a/readme.txt
+++ b/readme.txt
@@ -4,12 +4,12 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.2
+Stable tag: 0.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
-This plugin powers the PSPA membership system and integrates with WooCommerce and Advanced Custom Fields (ACF) Pro.
+This plugin powers the PSPA membership system and integrates with WooCommerce and Advanced Custom Fields (ACF) Pro. It provides a graduate dashboard, administrator search tools and a login-by-details shortcode.
 
 == Custom User Roles ==
 The plugin registers two custom user roles:
@@ -28,12 +28,18 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.3 =
+* Added administrator search and editing interface on the graduate profile endpoint.
+* Implemented `[pspa_login_by_details]` shortcode for logging in by first name, last name and graduation year.
+* Added role-based redirection to the graduate profile and blocked backend access.
 = 0.0.2 =
 * Added "Προφίλ Απόφοιτου" WooCommerce endpoint for graduates to edit their personal details.
 = 0.0.1 =
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.3 =
+Introduces administrator editing, login-by-details and role-based redirects.
 = 0.0.2 =
 Adds a WooCommerce endpoint for graduates to update their profile.
 = 0.0.1 =


### PR DESCRIPTION
## Summary
- add admin-facing search and edit interface on Graduate Profile endpoint
- add `[pspa_login_by_details]` shortcode for login via personal details
- force graduates and System Admins to front-end dashboard and prevent backend access

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc2dbc97d0832785aa730d2f0cb026