### PR TITLE
Render full ACF profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The `Graduate Profile Dashboard` provides a single-page front-end form for gradu
 
 Key features:
 
-- **Per-field visibility toggles** – graduates can decide which profile fields are publicly visible.
-- **ACF-based form** – all profile fields are rendered using ACF Pro, with tabs hidden to keep the form on one page.
-- **Profile image uploads** – graduates are granted the `upload_files` capability to change their profile photo.
-- **Name synchronization** – the user's WordPress first name, last name and display name are updated after saving the form.
+ - **Per-field visibility toggles** – graduates can decide which profile fields are publicly visible.
+ - **ACF-based form** – all profile fields are rendered using ACF Pro, with tabs hidden to keep the form on one page.
+ - **Profile image uploads** – graduates are granted the `upload_files` capability to change their profile photo.
+ - **Name synchronization** – the user's WordPress first name, last name and display name are updated after saving the form.
 - **WooCommerce integration** – registers a custom endpoint and navigation item under "My Account" so graduates can access the dashboard.
 - **Global visibility mode lock** – the `gn_visibility_mode` field is hidden on the front end and cannot be changed by graduates.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.3
+Stable tag: 0.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.4 =
+* Render all graduate profile fields via ACF on the front-end form.
+* Added name synchronization with WordPress user fields after saving.
+
 = 0.0.3 =
 * Added administrator search and editing interface on the graduate profile endpoint.
 * Implemented `[pspa_login_by_details]` shortcode for logging in by first name, last name and graduation year.
@@ -38,6 +42,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.4 =
+Displays full ACF profile fields and syncs user names.
+
 = 0.0.3 =
 Introduces administrator editing, login-by-details and role-based redirects.
 = 0.0.2 =


### PR DESCRIPTION
## Summary
- Render full ACF Graduate Profile field group on front-end form with PSPA color styling
- Sync ACF name fields with WordPress user names
- Bump plugin version to 0.0.4 and update docs

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3051288483278017eda901647e8b