### PR TITLE
Hide visibility settings tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,3 @@ The plugin registers a **Graduate Profile** field group in Advanced Custom Field
 - **Εμφάνιση στο δημόσιο προφίλ: Τίτλος** (`gn_show_job_title`, true_false)
 - **Θέση-Εταιρεία** (`gn_position_company`, text)
 - **Εμφάνιση στο δημόσιο προφίλ: Θέση-Εταιρεία** (`gn_show_position_company`, true_false)
-
-### Ρυθμίσεις ορατότητας
-- **Λειτουργία ορατότητας** (`gn_visibility_mode`, radio)

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.4
+ * Version: 0.0.5
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -117,6 +117,23 @@ function pspa_ms_maybe_acf_form_head() {
     }
 }
 add_action( 'template_redirect', 'pspa_ms_maybe_acf_form_head' );
+
+/**
+ * Hide the "Ρυθμίσεις ορατότητας" tab and associated control field.
+ *
+ * The graduate profile field group uses ACF tabs for internal organization but
+ * the front-end form should display as a single page. This filter removes the
+ * visibility settings tab (`tab_gn_visibility`) and the `gn_visibility_mode`
+ * field so no user can access them.
+ *
+ * @param array $field Field settings.
+ * @return false
+ */
+function pspa_ms_hide_visibility_fields( $field ) {
+    return false;
+}
+add_filter( 'acf/prepare_field/key=tab_gn_visibility', 'pspa_ms_hide_visibility_fields' );
+add_filter( 'acf/prepare_field/name=gn_visibility_mode', 'pspa_ms_hide_visibility_fields' );
 
 /**
  * Render Graduate Profile endpoint content.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.4
+Stable tag: 0.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.5 =
+* Hide the "Ρυθμίσεις ορατότητας" tab from the graduate profile form.
+
 = 0.0.4 =
 * Render all graduate profile fields via ACF on the front-end form.
 * Added name synchronization with WordPress user fields after saving.
@@ -42,6 +45,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.5 =
+Removes the visibility settings tab from the profile dashboard.
+
 = 0.0.4 =
 Displays full ACF profile fields and syncs user names.
 


### PR DESCRIPTION
## Summary
- hide ACF "Ρυθμίσεις ορατότητας" tab and lock down its control field
- bump PSPA Membership System to version 0.0.5
- update documentation and changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc344c0ae48327bf6b2320384f9188