### PR TITLE
Translate 'Save changes' buttons to Greek and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.5
+ * Version: 0.0.6
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -220,7 +220,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
         <?php wp_nonce_field( 'pspa_graduate_profile', 'pspa_graduate_profile_nonce' ); ?>
         <p>
             <button type="submit" class="woocommerce-Button button">
-                <?php esc_html_e( 'Save changes', 'pspa-membership-system' ); ?>
+                <?php esc_html_e( 'Αποθήκευση αλλαγών', 'pspa-membership-system' ); ?>
             </button>
         </p>
     </form>
@@ -344,7 +344,7 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
         <?php endif; ?>
         <?php wp_nonce_field( 'pspa_admin_edit_user', 'pspa_admin_edit_user_nonce' ); ?>
         <p>
-            <button type="submit" class="woocommerce-Button button"><?php esc_html_e( 'Save changes', 'pspa-membership-system' ); ?></button>
+            <button type="submit" class="woocommerce-Button button"><?php esc_html_e( 'Αποθήκευση αλλαγών', 'pspa-membership-system' ); ?></button>
         </p>
     </form>
     <?php

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.5
+Stable tag: 0.0.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.6 =
+* Translate "Save changes" buttons to Greek.
+
 = 0.0.5 =
 * Hide the "Ρυθμίσεις ορατότητας" tab from the graduate profile form.
 
@@ -45,6 +48,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.6 =
+Translates "Save changes" buttons to Greek.
+
 = 0.0.5 =
 Removes the visibility settings tab from the profile dashboard.
 


### PR DESCRIPTION
## Summary
- Localize "Save changes" buttons to Greek for graduate profile forms
- Bump plugin version to 0.0.6 with updated readme changelog and upgrade notice

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc359247ec832784eb6b28c77d3bf8