### PR TITLE
Fix login-by-details shortcode registration and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.6
+ * Version: 0.0.7
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -401,6 +401,10 @@ function pspa_ms_login_by_details_shortcode() {
             $user = $users[0];
             wp_set_current_user( $user->ID );
             wp_set_auth_cookie( $user->ID, true );
+            /**
+             * Fire the login hook so other plugins can perform actions on login.
+             */
+            do_action( 'wp_login', $user->user_login, $user );
             wp_safe_redirect( wc_get_account_endpoint_url( 'graduate-profile' ) );
             exit;
         } else {
@@ -432,7 +436,14 @@ function pspa_ms_login_by_details_shortcode() {
     $output .= ob_get_clean();
     return $output;
 }
-add_shortcode( 'pspa_login_by_details', 'pspa_ms_login_by_details_shortcode' );
+
+/**
+ * Register plugin shortcodes.
+ */
+function pspa_ms_register_shortcodes() {
+    add_shortcode( 'pspa_login_by_details', 'pspa_ms_login_by_details_shortcode' );
+}
+add_action( 'init', 'pspa_ms_register_shortcodes' );
 
 /**
  * Sync first, last and display names with ACF fields after saving.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.6
+Stable tag: 0.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.7 =
+* Fix `[pspa_login_by_details]` shortcode not rendering and ensure login actions run.
+
 = 0.0.6 =
 * Translate "Save changes" buttons to Greek.
 
@@ -48,6 +51,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.7 =
+Resolves missing login form and triggers login hooks when authenticating by details.
+
 = 0.0.6 =
 Translates "Save changes" buttons to Greek.
 


### PR DESCRIPTION
## Summary
- Ensure login-by-details shortcode registers on `init` and triggers `wp_login` hook on successful match.
- Bump plugin version to 0.0.7 and document the change in the readme.

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3723d274832798cbde974536c9df