### PR TITLE
Add graduate directory shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ System Admins and site administrators can search for graduates and edit any user
 
 The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard.
 
+## Graduate Directory
+
+The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking a card or the "Δείτε Περισσότερα" link opens the graduate's public, non-editable profile.
+
 ## Role-based Redirection
 
 Graduates and System Admins are redirected to the `Προφίλ Απόφοιτου` dashboard after login and are prevented from accessing the WordPress admin area.

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.7
+ * Version: 0.0.8
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -438,10 +438,85 @@ function pspa_ms_login_by_details_shortcode() {
 }
 
 /**
+ * Shortcode: list graduates and display individual profile.
+ *
+ * Usage: [pspa_graduate_directory]
+ * Clicking a graduate card appends ?graduate=ID to the URL and renders
+ * the selected profile in a read-only format.
+ *
+ * @return string
+ */
+function pspa_ms_graduate_directory_shortcode() {
+    $view_id = isset( $_GET['graduate'] ) ? absint( $_GET['graduate'] ) : 0;
+
+    if ( $view_id ) {
+        $user = get_user_by( 'id', $view_id );
+        if ( ! $user || ! in_array( 'professionalcatalogue', (array) $user->roles, true ) ) {
+            return '';
+        }
+
+        $first  = get_field( 'gn_first_name', 'user_' . $view_id );
+        $last   = get_field( 'gn_surname', 'user_' . $view_id );
+        $year   = get_field( 'gn_graduation_year', 'user_' . $view_id );
+        $img_id = get_field( 'gn_profile_picture', 'user_' . $view_id );
+        $image  = $img_id ? wp_get_attachment_image( $img_id, 'medium' ) : get_avatar( $view_id, 192 );
+
+        ob_start();
+        echo '<div class="pspa-graduate-profile">';
+        echo '<div class="pspa-profile-picture">' . $image . '</div>';
+        echo '<h2>' . esc_html( trim( $first . ' ' . $last ) ) . '</h2>';
+        if ( $year ) {
+            echo '<p class="pspa-grad-year">' . esc_html__( 'Αποφοίτηση:', 'pspa-membership-system' ) . ' ' . esc_html( $year ) . '</p>';
+        }
+        echo '</div>';
+        return ob_get_clean();
+    }
+
+    $users = get_users(
+        array(
+            'role'   => 'professionalcatalogue',
+            'orderby'=> 'display_name',
+            'order'  => 'ASC',
+            'number' => -1,
+        )
+    );
+
+    if ( empty( $users ) ) {
+        return '<p>' . esc_html__( 'No graduates found.', 'pspa-membership-system' ) . '</p>';
+    }
+
+    ob_start();
+    echo '<div class="pspa-graduate-directory">';
+    foreach ( $users as $user ) {
+        $uid    = $user->ID;
+        $first  = get_field( 'gn_first_name', 'user_' . $uid );
+        $last   = get_field( 'gn_surname', 'user_' . $uid );
+        $year   = get_field( 'gn_graduation_year', 'user_' . $uid );
+        $img_id = get_field( 'gn_profile_picture', 'user_' . $uid );
+        $image  = $img_id ? wp_get_attachment_image( $img_id, 'thumbnail' ) : get_avatar( $uid, 96 );
+        $link   = esc_url( add_query_arg( 'graduate', $uid ) );
+
+        echo '<div class="pspa-graduate-card">';
+        echo '<a href="' . $link . '">';
+        echo '<div class="pspa-card-image">' . $image . '</div>';
+        echo '<h3>' . esc_html( trim( $first . ' ' . $last ) ) . '</h3>';
+        if ( $year ) {
+            echo '<p class="pspa-grad-year">' . esc_html( $year ) . '</p>';
+        }
+        echo '<span class="pspa-more">' . esc_html__( 'Δείτε Περισσότερα', 'pspa-membership-system' ) . '</span>';
+        echo '</a>';
+        echo '</div>';
+    }
+    echo '</div>';
+    return ob_get_clean();
+}
+
+/**
  * Register plugin shortcodes.
  */
 function pspa_ms_register_shortcodes() {
     add_shortcode( 'pspa_login_by_details', 'pspa_ms_login_by_details_shortcode' );
+    add_shortcode( 'pspa_graduate_directory', 'pspa_ms_graduate_directory_shortcode' );
 }
 add_action( 'init', 'pspa_ms_register_shortcodes' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.7
+Stable tag: 0.0.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.8 =
+* Add `[pspa_graduate_directory]` shortcode to display graduate cards and view non-editable profiles.
 = 0.0.7 =
 * Fix `[pspa_login_by_details]` shortcode not rendering and ensure login actions run.
 
@@ -51,6 +53,8 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.8 =
+Introduces a graduate directory shortcode and public profile view.
 = 0.0.7 =
 Resolves missing login form and triggers login hooks when authenticating by details.
 


### PR DESCRIPTION
## Summary
- add `[pspa_graduate_directory]` shortcode for listing graduates and viewing their public profile
- document new shortcode and bump plugin version to 0.0.8

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc3915d90c8327b79bbabd6af9a4a6