### PR TITLE
Add graduate directory with AJAX filters

### DIFF
--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -1,0 +1,36 @@
+.pspa-graduate-directory {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+#pspa-graduate-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    margin-bottom: 1em;
+}
+
+#pspa-graduate-filters select {
+    min-width: 150px;
+}
+
+.pspa-graduate-card {
+    display: flex;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 1em;
+    margin-bottom: 1em;
+    background: #fff;
+}
+
+.pspa-graduate-avatar {
+    margin-right: 1em;
+}
+
+.pspa-graduate-details h3 {
+    margin: 0;
+}
+
+.pspa-graduate-details p {
+    margin: 0.2em 0;
+}

--- a/assets/js/graduate-directory.js
+++ b/assets/js/graduate-directory.js
@@ -1,0 +1,20 @@
+jQuery(function($){
+    function fetchGraduates(){
+        var data = {
+            action: 'pspa_ms_filter_graduates',
+            nonce: pspaMsDir.nonce,
+            profession: $('#pspa-graduate-filters [name="profession"]').val(),
+            job_title: $('#pspa-graduate-filters [name="job_title"]').val(),
+            city: $('#pspa-graduate-filters [name="city"]').val(),
+            country: $('#pspa-graduate-filters [name="country"]').val()
+        };
+        $.post(pspaMsDir.ajaxUrl, data, function(response){
+            if(response.success){
+                $('#pspa-graduate-results').html(response.data.html);
+            }
+        });
+    }
+
+    $('#pspa-graduate-filters').on('change', 'select', fetchGraduates);
+    fetchGraduates();
+});

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.7
+Stable tag: 0.0.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.8 =
+* Add graduate directory with AJAX filters restricted to logged-in users.
+
 = 0.0.7 =
 * Fix `[pspa_login_by_details]` shortcode not rendering and ensure login actions run.
 
@@ -51,6 +54,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.8 =
+Introduces a LinkedIn-style graduate directory with dynamic filters.
+
 = 0.0.7 =
 Resolves missing login form and triggers login hooks when authenticating by details.
 


### PR DESCRIPTION
## Summary
- implement LinkedIn-style graduate directory shortcode only accessible to logged in users
- add dynamic AJAX filters for occupation, job title, town and country
- include styling/JS assets and bump plugin version to 0.0.8

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc3b1efae48327b8ec70b32b2ee652