### PR TITLE
Fix duplicate shortcode causing activation failure, bump to 0.0.9

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.8
+ * Version: 0.0.9
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.8' );
+define( 'PSPA_MS_VERSION', '0.0.9' );
 
 /**
  * Ensure required plugins are active.
@@ -437,80 +437,6 @@ function pspa_ms_login_by_details_shortcode() {
     <?php
     $output .= ob_get_clean();
     return $output;
-}
-
-/**
- * Shortcode: list graduates and display individual profile.
- *
- * Usage: [pspa_graduate_directory]
- * Clicking a graduate card appends ?graduate=ID to the URL and renders
- * the selected profile in a read-only format.
- *
- * @return string
- */
-function pspa_ms_graduate_directory_shortcode() {
-    $view_id = isset( $_GET['graduate'] ) ? absint( $_GET['graduate'] ) : 0;
-
-    if ( $view_id ) {
-        $user = get_user_by( 'id', $view_id );
-        if ( ! $user || ! in_array( 'professionalcatalogue', (array) $user->roles, true ) ) {
-            return '';
-        }
-
-        $first  = get_field( 'gn_first_name', 'user_' . $view_id );
-        $last   = get_field( 'gn_surname', 'user_' . $view_id );
-        $year   = get_field( 'gn_graduation_year', 'user_' . $view_id );
-        $img_id = get_field( 'gn_profile_picture', 'user_' . $view_id );
-        $image  = $img_id ? wp_get_attachment_image( $img_id, 'medium' ) : get_avatar( $view_id, 192 );
-
-        ob_start();
-        echo '<div class="pspa-graduate-profile">';
-        echo '<div class="pspa-profile-picture">' . $image . '</div>';
-        echo '<h2>' . esc_html( trim( $first . ' ' . $last ) ) . '</h2>';
-        if ( $year ) {
-            echo '<p class="pspa-grad-year">' . esc_html__( 'Αποφοίτηση:', 'pspa-membership-system' ) . ' ' . esc_html( $year ) . '</p>';
-        }
-        echo '</div>';
-        return ob_get_clean();
-    }
-
-    $users = get_users(
-        array(
-            'role'   => 'professionalcatalogue',
-            'orderby'=> 'display_name',
-            'order'  => 'ASC',
-            'number' => -1,
-        )
-    );
-
-    if ( empty( $users ) ) {
-        return '<p>' . esc_html__( 'No graduates found.', 'pspa-membership-system' ) . '</p>';
-    }
-
-    ob_start();
-    echo '<div class="pspa-graduate-directory">';
-    foreach ( $users as $user ) {
-        $uid    = $user->ID;
-        $first  = get_field( 'gn_first_name', 'user_' . $uid );
-        $last   = get_field( 'gn_surname', 'user_' . $uid );
-        $year   = get_field( 'gn_graduation_year', 'user_' . $uid );
-        $img_id = get_field( 'gn_profile_picture', 'user_' . $uid );
-        $image  = $img_id ? wp_get_attachment_image( $img_id, 'thumbnail' ) : get_avatar( $uid, 96 );
-        $link   = esc_url( add_query_arg( 'graduate', $uid ) );
-
-        echo '<div class="pspa-graduate-card">';
-        echo '<a href="' . $link . '">';
-        echo '<div class="pspa-card-image">' . $image . '</div>';
-        echo '<h3>' . esc_html( trim( $first . ' ' . $last ) ) . '</h3>';
-        if ( $year ) {
-            echo '<p class="pspa-grad-year">' . esc_html( $year ) . '</p>';
-        }
-        echo '<span class="pspa-more">' . esc_html__( 'Δείτε Περισσότερα', 'pspa-membership-system' ) . '</span>';
-        echo '</a>';
-        echo '</div>';
-    }
-    echo '</div>';
-    return ob_get_clean();
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.8
+Stable tag: 0.0.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.9 =
+* Fix fatal error during activation caused by duplicate shortcode definitions.
 = 0.0.8 =
 
 * Add graduate directory with AJAX filters restricted to logged-in users.
@@ -56,6 +58,8 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.9 =
+Resolves a fatal error preventing plugin activation.
 = 0.0.8 =
 Introduces a LinkedIn-style graduate directory with dynamic filters.
 


### PR DESCRIPTION
## Summary
- remove duplicate `pspa_ms_graduate_directory_shortcode` definition that triggered a fatal error
- bump plugin version to 0.0.9 and update readme

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3f5323348327aaa5932f1ca480d5