### PR TITLE
Fix login by details shortcode and show verified message

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.10
+ * Version: 0.0.11
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.10' );
+define( 'PSPA_MS_VERSION', '0.0.11' );
 
 /**
  * Enqueue shared dashboard styles.
@@ -361,7 +361,7 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
  */
 function pspa_ms_login_by_details_shortcode() {
     if ( is_user_logged_in() ) {
-        return '';
+        return '<p>' . esc_html__( 'Είστε ήδη επαληθευμένοι.', 'pspa-membership-system' ) . '</p>';
     }
 
     pspa_ms_enqueue_dashboard_styles();
@@ -405,11 +405,8 @@ function pspa_ms_login_by_details_shortcode() {
 
         if ( ! empty( $users ) ) {
             $user = $users[0];
-            wp_set_current_user( $user->ID );
+            wp_set_current_user( $user->ID, $user->user_login );
             wp_set_auth_cookie( $user->ID, true );
-            /**
-             * Fire the login hook so other plugins can perform actions on login.
-             */
             do_action( 'wp_login', $user->user_login, $user );
             wp_safe_redirect( wc_get_account_endpoint_url( 'graduate-profile' ) );
             exit;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.10
+Stable tag: 0.0.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.11 =
+* Διορθώθηκε η σύνδεση μέσω `[pspa_login_by_details]` και εμφανίζεται μήνυμα όταν είστε ήδη επαληθευμένοι.
 = 0.0.10 =
 * Μεταφράστηκαν όλα τα κουμπιά και οι προεπιλεγμένες επιλογές στα ελληνικά.
 * Εφαρμόστηκε ενιαία εμφάνιση στα shortcodes και οι κάρτες αποφοίτων είναι πλέον κλικαμπλ.
@@ -62,6 +64,8 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.11 =
+Διορθώνει τη σύνδεση μέσω στοιχείων και εμφανίζει μήνυμα επαλήθευσης για συνδεδεμένους χρήστες.
 = 0.0.10 =
 Βελτιωμένη εμπειρία χρήστη με ελληνικά κουμπιά, ενοποιημένο στυλ και κλικαμπλ κάρτες αποφοίτων.
 = 0.0.9 =


### PR DESCRIPTION
## Summary
- ensure `[pspa_login_by_details]` logs users in correctly
- show a verification message when the user is already logged in
- bump plugin version to 0.0.11

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4c3c12ec8327b720265e16c353c1