### PR TITLE
Add login debug logger and hide verify menu

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.11
+Stable tag: 0.0.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.12 =
+* Added admin logger for troubleshooting login attempts and hide the login-by-details menu for verified users.
 = 0.0.11 =
 * Διορθώθηκε η σύνδεση μέσω `[pspa_login_by_details]` και εμφανίζεται μήνυμα όταν είστε ήδη επαληθευμένοι.
 = 0.0.10 =
@@ -64,6 +66,8 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.12 =
+Adds admin logger for troubleshooting login attempts and hides the login-by-details menu once verified.
 = 0.0.11 =
 Διορθώνει τη σύνδεση μέσω στοιχείων και εμφανίζει μήνυμα επαλήθευσης για συνδεδεμένους χρήστες.
 = 0.0.10 =


### PR DESCRIPTION
## Summary
- bump plugin to v0.0.12
- add logging utilities and admin page to troubleshoot `pspa_login_by_details` attempts
- hide login-by-details menu entry and log status when user already verified

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e71134c832788c2b12d654d0c11