### PR TITLE
Generalize logger and add verbose debug logs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.12
+Stable tag: 0.0.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.13 =
+* Generalized logger and added verbose debug logs across the plugin.
+
 = 0.0.12 =
 * Added admin logger for troubleshooting login attempts and hide the login-by-details menu for verified users.
 = 0.0.11 =
@@ -66,6 +69,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.13 =
+Generalizes the logger and adds verbose debug logs across the plugin.
+
 = 0.0.12 =
 Adds admin logger for troubleshooting login attempts and hides the login-by-details menu once verified.
 = 0.0.11 =


### PR DESCRIPTION
## Summary
- generalize logger to support levels and context with optional WP_DEBUG output
- add extensive log calls across plugin and display log level in admin page
- bump plugin version to 0.0.13

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4fbe4b348327bcae966cc779d171