### PR TITLE
Ensure dependencies are checked before loading frontend

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.13
+ * Version: 0.0.14
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.13' );
+define( 'PSPA_MS_VERSION', '0.0.14' );
 
 /**
  * Enqueue shared dashboard styles.
@@ -32,10 +32,6 @@ function pspa_ms_enqueue_dashboard_styles() {
  * Ensure required plugins are active.
  */
 function pspa_ms_check_dependencies() {
-    if ( ! is_admin() ) {
-        return;
-    }
-
     require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
     $required_plugins = array(
@@ -54,25 +50,33 @@ function pspa_ms_check_dependencies() {
 
     if ( ! empty( $missing_plugins ) ) {
         pspa_ms_log( 'Missing plugins: ' . implode( ', ', $missing_plugins ), 'error' );
-        add_action(
-            'admin_notices',
-            static function () use ( $missing_plugins ) {
-                echo '<div class="notice notice-error"><p>';
-                printf(
-                    'PSPA Membership System requires the following plugins to be active: %s.',
-                    esc_html( implode( ', ', $missing_plugins ) )
-                );
-                echo '</p></div>';
-            }
-        );
+
+        if ( is_admin() ) {
+            add_action(
+                'admin_notices',
+                static function () use ( $missing_plugins ) {
+                    echo '<div class="notice notice-error"><p>';
+                    printf(
+                        'PSPA Membership System requires the following plugins to be active: %s.',
+                        esc_html( implode( ', ', $missing_plugins ) )
+                    );
+                    echo '</p></div>';
+                }
+            );
+        }
 
         deactivate_plugins( plugin_basename( __FILE__ ) );
-    } else {
-        pspa_ms_log( 'All required plugins active.' );
+
+        return false;
     }
+
+    pspa_ms_log( 'All required plugins active.' );
+    return true;
 }
 
-pspa_ms_check_dependencies();
+if ( ! pspa_ms_check_dependencies() ) {
+    return;
+}
 
 // Load the plugin update checker library.
 require plugin_dir_path( __FILE__ ) . 'plugin-update-checker/plugin-update-checker.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.13
+Stable tag: 0.0.14
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.14 =
+* Prevent the plugin from loading when required dependencies are missing to avoid blank front-end pages.
+
 = 0.0.13 =
 * Generalized logger and added verbose debug logs across the plugin.
 
@@ -69,6 +72,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.14 =
+Ensures missing dependencies are detected early, preventing blank pages on the front end.
+
 = 0.0.13 =
 Generalizes the logger and adds verbose debug logs across the plugin.
 


### PR DESCRIPTION
## Summary
- Halt plugin execution if required dependencies are missing to avoid blank frontend pages
- Bump plugin version to 0.0.14 and update documentation

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc51c407f88327834b78dceef480eb