### PR TITLE
Hide visibility toggles on public profile and bump version to 0.0.12

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.11
+ * Version: 0.0.12
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.11' );
+define( 'PSPA_MS_VERSION', '0.0.12' );
 
 /**
  * Enqueue shared dashboard styles.
@@ -148,6 +148,23 @@ function pspa_ms_hide_visibility_fields( $field ) {
 }
 add_filter( 'acf/prepare_field/key=tab_gn_visibility', 'pspa_ms_hide_visibility_fields' );
 add_filter( 'acf/prepare_field/name=gn_visibility_mode', 'pspa_ms_hide_visibility_fields' );
+
+/**
+ * Hide "show on public profile" toggles when viewing public profiles.
+ *
+ * @param array $field Field settings.
+ * @return array|false
+ */
+function pspa_ms_hide_public_visibility_toggles( $field ) {
+    if ( 0 === strpos( $field['name'], 'gn_show_' ) ) {
+        if ( function_exists( 'is_account_page' ) && is_account_page() && false !== get_query_var( 'graduate-profile', false ) ) {
+            return $field;
+        }
+        return false;
+    }
+    return $field;
+}
+add_filter( 'acf/prepare_field', 'pspa_ms_hide_public_visibility_toggles', 20 );
 
 /**
  * Render Graduate Profile endpoint content.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.11
+Stable tag: 0.0.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.12 =
+* Fix duplicated "Α (ΠΟΒΙΩΣΑΣ) – Απεβίωσε" field on public profile.
 = 0.0.11 =
 * Διορθώθηκε η σύνδεση μέσω `[pspa_login_by_details]` και εμφανίζεται μήνυμα όταν είστε ήδη επαληθευμένοι.
 = 0.0.10 =
@@ -64,6 +66,8 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 * Initial release.
 
 == Upgrade Notice ==
+= 0.0.12 =
+Επιλύει διπλή εμφάνιση του πεδίου "Α (ΠΟΒΙΩΣΑΣ) – Απεβίωσε" στο δημόσιο προφίλ.
 = 0.0.11 =
 Διορθώνει τη σύνδεση μέσω στοιχείων και εμφανίζει μήνυμα επαλήθευσης για συνδεδεμένους χρήστες.
 = 0.0.10 =


### PR DESCRIPTION
## Summary
- prevent `gn_show_*` visibility toggles from appearing on public profiles
- bump plugin version to 0.0.12 and update documentation

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc5574294483278a68e4b2a4e02f0f