### PR TITLE
Add public profile links and paginate graduate directory

### DIFF
--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -45,3 +45,19 @@
     color: #fff;
     border-radius: 4px;
 }
+
+.pspa-dir-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1em;
+    margin-top: 1em;
+}
+
+.pspa-dir-pagination a {
+    padding: 0.4em 0.8em;
+    background: var(--ink, #3b2b22);
+    color: #fff;
+    border-radius: 4px;
+    text-decoration: none;
+}

--- a/assets/js/graduate-directory.js
+++ b/assets/js/graduate-directory.js
@@ -1,4 +1,6 @@
 jQuery(function($){
+    let currentPage = 1;
+
     function fetchGraduates(){
         var data = {
             action: 'pspa_ms_filter_graduates',
@@ -6,7 +8,8 @@ jQuery(function($){
             profession: $('#pspa-graduate-filters [name="profession"]').val(),
             job_title: $('#pspa-graduate-filters [name="job_title"]').val(),
             city: $('#pspa-graduate-filters [name="city"]').val(),
-            country: $('#pspa-graduate-filters [name="country"]').val()
+            country: $('#pspa-graduate-filters [name="country"]').val(),
+            page: currentPage
         };
         $.post(pspaMsDir.ajaxUrl, data, function(response){
             if(response.success){
@@ -15,6 +18,16 @@ jQuery(function($){
         });
     }
 
-    $('#pspa-graduate-filters').on('change', 'select', fetchGraduates);
+    $('#pspa-graduate-filters').on('change', 'select', function(){
+        currentPage = 1;
+        fetchGraduates();
+    });
+
+    $('#pspa-graduate-results').on('click', '.pspa-dir-pagination a', function(e){
+        e.preventDefault();
+        currentPage = $(this).data('page');
+        fetchGraduates();
+    });
+
     fetchGraduates();
 });

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.12
+Stable tag: 0.0.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.13 =
+* Link graduate cards to dedicated public profiles instead of author pages.
+* Add AJAX pagination to the graduate directory for faster initial load.
+
 = 0.0.12 =
 * Fix duplicated "Α (ΠΟΒΙΩΣΑΣ) – Απεβίωσε" field on public profile.
 = 0.0.11 =


### PR DESCRIPTION
## Summary
- Link graduate directory cards to dedicated public profile pages
- Add AJAX-based pagination to graduate directory for faster load times
- Bump plugin version to 0.0.13

## Testing
- `php -l pspa-membership-system.php`
- `node --check assets/js/graduate-directory.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc58f9b3ec8327a77c6bea41a19cb5