### PR TITLE
Add public graduate profile route and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `[pspa_login_by_details]` shortcode renders a form asking for first name, la
 
 ## Graduate Directory
 
-The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking a card or the "Δείτε Περισσότερο" link opens the graduate's public, non-editable profile.
+The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking a card or the "Δείτε Περισσότερο" link opens the graduate's public, non-editable profile. Public profiles are also accessible directly at `/graduate/<username>/`.
 
 ## Role-based Redirection
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.13
+Stable tag: 0.0.14
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.14 =
+* Add `/graduate/` rewrite rule and public profile template.
 = 0.0.13 =
 * Link graduate cards to dedicated public profiles instead of author pages.
 * Add AJAX pagination to the graduate directory for faster initial load.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template for public graduate profiles.
+ *
+ * @package PSPA\MembershipSystem
+ */
+
+$pspa_user = get_query_var( 'pspa_graduate_user' );
+
+if ( ! $pspa_user instanceof WP_User ) {
+    get_header();
+    echo '<div class="pspa-dashboard"><p>' . esc_html__( 'Ο απόφοιτος δεν βρέθηκε.', 'pspa-membership-system' ) . '</p></div>';
+    get_footer();
+    return;
+}
+
+pspa_ms_enqueue_dashboard_styles();
+get_header();
+
+$job        = function_exists( 'get_field' ) ? (string) get_field( 'gn_job_title', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_job_title', true );
+$company    = function_exists( 'get_field' ) ? (string) get_field( 'gn_position_company', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_position_company', true );
+$profession = function_exists( 'get_field' ) ? (string) get_field( 'gn_profession', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_profession', true );
+$city       = function_exists( 'get_field' ) ? (string) get_field( 'gn_city', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_city', true );
+$country    = function_exists( 'get_field' ) ? (string) get_field( 'gn_country', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_country', true );
+?>
+<div class="pspa-graduate-profile pspa-dashboard">
+    <div class="pspa-graduate-header">
+        <div class="pspa-graduate-avatar"><?php echo get_avatar( $pspa_user->ID, 128 ); ?></div>
+        <h1 class="pspa-graduate-name"><?php echo esc_html( $pspa_user->display_name ); ?></h1>
+        <?php if ( $job || $company ) : ?>
+            <p class="pspa-graduate-title"><?php echo esc_html( trim( $job . ( $company ? ' - ' . $company : '' ) ) ); ?></p>
+        <?php endif; ?>
+        <?php if ( $profession ) : ?>
+            <p class="pspa-graduate-profession"><?php echo esc_html( $profession ); ?></p>
+        <?php endif; ?>
+        <?php if ( $city || $country ) : ?>
+            <p class="pspa-graduate-location"><?php echo esc_html( trim( $city . ( $country ? ', ' . $country : '' ) ) ); ?></p>
+        <?php endif; ?>
+    </div>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- add `/graduate/<username>/` rewrite rule and template for public graduate profiles
- document new public profile route and bump plugin version to 0.0.14

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc5bf630d8832784cbf6b64aea3c1d