### PR TITLE
Display all ACF profile fields

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.14
+ * Version: 0.0.15
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.14' );
+define( 'PSPA_MS_VERSION', '0.0.15' );
 
 /**
  * Enqueue shared dashboard styles.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.14
+Stable tag: 0.0.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.15 =
+* Display all graduate profile ACF fields on public profile template.
+
 = 0.0.14 =
 * Add `/graduate/` rewrite rule and public profile template.
 = 0.0.13 =


### PR DESCRIPTION
## Summary
- render graduate profile template fields read-only, showing custom profile picture and all ACF fields
- bump plugin version to 0.0.15

## Testing
- `php -l templates/graduate-public-profile.php`
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e6928e08327bb9bde34b0733763