### PR TITLE
Ensure public profile shows all ACF fields

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.17
+ * Version: 0.0.18
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.17' );
+define( 'PSPA_MS_VERSION', '0.0.18' );
 
 /**
  * Enqueue shared dashboard styles.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.17
+Stable tag: 0.0.18
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.18 =
+* Ensure public graduate profile displays all ACF fields reliably.
+
 = 0.0.17 =
 * Honor profile visibility mode and field visibility settings on the public profile template.
 

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -61,10 +61,10 @@ $show_country = function_exists( 'get_field' ) ? get_field( 'gn_show_country', '
             <p class="pspa-graduate-location"><?php echo esc_html( trim( $city_display . ( $country_display ? ', ' . $country_display : '' ) ) ); ?></p>
         <?php endif; ?>
     </div>
-    <?php if ( function_exists( 'acf_get_fields' ) && 'hide_all' !== $visibility ) : ?>
+    <?php if ( function_exists( 'get_fields' ) && 'hide_all' !== $visibility ) : ?>
         <div class="pspa-graduate-details">
             <?php
-            $fields        = acf_get_fields( 'group_gn_graduate_profile' );
+            $fields        = get_fields( 'user_' . $pspa_user->ID );
             $header_fields = array(
                 'gn_job_title',
                 'gn_position_company',
@@ -74,31 +74,29 @@ $show_country = function_exists( 'get_field' ) ? get_field( 'gn_show_country', '
                 'gn_profile_picture',
             );
             if ( $fields ) {
-                foreach ( $fields as $field ) {
-                    if ( 'tab' === $field['type'] ) {
+                foreach ( $fields as $name => $value ) {
+                    if ( 'gn_visibility_mode' === $name || 0 === strpos( $name, 'gn_show_' ) ) {
                         continue;
                     }
-                    if ( 'gn_visibility_mode' === $field['name'] || 0 === strpos( $field['name'], 'gn_show_' ) ) {
-                        continue;
-                    }
-                    if ( in_array( $field['name'], $header_fields, true ) ) {
+                    if ( in_array( $name, $header_fields, true ) ) {
                         continue;
                     }
                     if ( 'show_all' !== $visibility ) {
-                        $show = function_exists( 'get_field' ) ? get_field( 'gn_show_' . $field['name'], 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_' . $field['name'], true );
+                        $show = function_exists( 'get_field' ) ? get_field( 'gn_show_' . $name, 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_' . $name, true );
                         if ( null !== $show && ! $show ) {
                             continue;
                         }
                     }
-                    $value = function_exists( 'get_field' ) ? get_field( $field['name'], 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, $field['name'], true );
-                    if ( 'true_false' === $field['type'] ) {
-                        if ( empty( $value ) ) {
+                    $field_obj = function_exists( 'acf_get_field' ) ? acf_get_field( $name ) : false;
+                    $label     = $field_obj ? $field_obj['label'] : $name;
+                    if ( is_bool( $value ) ) {
+                        if ( ! $value ) {
                             continue;
                         }
                         printf(
                             '<p class="pspa-graduate-field pspa-graduate-field-%1$s"><strong>%2$s</strong></p>',
-                            esc_attr( $field['name'] ),
-                            esc_html( $field['label'] )
+                            esc_attr( $name ),
+                            esc_html( $label )
                         );
                         continue;
                     }
@@ -110,8 +108,8 @@ $show_country = function_exists( 'get_field' ) ? get_field( 'gn_show_country', '
                     }
                     printf(
                         '<p class="pspa-graduate-field pspa-graduate-field-%1$s"><strong>%2$s:</strong> %3$s</p>',
-                        esc_attr( $field['name'] ),
-                        esc_html( $field['label'] ),
+                        esc_attr( $name ),
+                        esc_html( $label ),
                         esc_html( $value )
                     );
                 }


### PR DESCRIPTION
## Summary
- use `get_fields()` to gather user ACF values for public graduate profiles
- bump plugin to version 0.0.18

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc65a67184832798fefba7c43ee451