### PR TITLE
Use dashboard layout for read-only graduate public profiles

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.18
+ * Version: 0.0.19
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.18' );
+define( 'PSPA_MS_VERSION', '0.0.19' );
 
 /**
  * Enqueue shared dashboard styles.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.18
+Stable tag: 0.0.19
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.19 =
+* Render public graduate profiles using the dashboard layout in read-only mode.
+
 = 0.0.18 =
 * Ensure public graduate profile displays all ACF fields reliably.
 

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -2,6 +2,9 @@
 /**
  * Template for public graduate profiles.
  *
+ * Displays the graduate profile using the same field layout as the
+ * `graduate-profile` My Account endpoint but in read-only mode.
+ *
  * @package PSPA\MembershipSystem
  */
 
@@ -17,106 +20,53 @@ if ( ! $pspa_user instanceof WP_User ) {
 pspa_ms_enqueue_dashboard_styles();
 get_header();
 
-$job        = function_exists( 'get_field' ) ? (string) get_field( 'gn_job_title', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_job_title', true );
-$company    = function_exists( 'get_field' ) ? (string) get_field( 'gn_position_company', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_position_company', true );
-$profession = function_exists( 'get_field' ) ? (string) get_field( 'gn_profession', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_profession', true );
-$city       = function_exists( 'get_field' ) ? (string) get_field( 'gn_city', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_city', true );
-$country    = function_exists( 'get_field' ) ? (string) get_field( 'gn_country', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_country', true );
-$picture    = function_exists( 'get_field' ) ? get_field( 'gn_profile_picture', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_profile_picture', true );
-$show_pic   = function_exists( 'get_field' ) ? get_field( 'gn_show_profile_picture', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_profile_picture', true );
 $visibility = function_exists( 'get_field' ) ? get_field( 'gn_visibility_mode', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_visibility_mode', true );
-$show_job   = function_exists( 'get_field' ) ? get_field( 'gn_show_job_title', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_job_title', true );
-$show_comp  = function_exists( 'get_field' ) ? get_field( 'gn_show_position_company', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_position_company', true );
-$show_prof  = function_exists( 'get_field' ) ? get_field( 'gn_show_profession', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_profession', true );
-$show_city  = function_exists( 'get_field' ) ? get_field( 'gn_show_city', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_city', true );
-$show_country = function_exists( 'get_field' ) ? get_field( 'gn_show_country', 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_country', true );
+
+// Hide fields according to individual visibility settings.
+$prepare_field = static function( $field ) use ( $pspa_user, $visibility ) {
+    if ( 'hide_all' === $visibility ) {
+        return false;
+    }
+
+    if ( 'show_all' !== $visibility ) {
+        $show = function_exists( 'get_field' ) ? get_field( 'gn_show_' . $field['name'], 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_' . $field['name'], true );
+
+        if ( null !== $show && ! $show ) {
+            return false;
+        }
+    }
+
+    return $field;
+};
+
+add_filter( 'acf/prepare_field', $prepare_field );
 ?>
 <div class="pspa-graduate-profile pspa-dashboard">
-    <div class="pspa-graduate-header">
-        <div class="pspa-graduate-avatar">
-            <?php
-            if ( $picture && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_pic || $show_pic ) ) {
-                echo wp_get_attachment_image( $picture, 'thumbnail' );
-            } else {
-                echo get_avatar( $pspa_user->ID, 128 );
-            }
-            ?>
-        </div>
-        <h1 class="pspa-graduate-name"><?php echo esc_html( $pspa_user->display_name ); ?></h1>
-        <?php
-        $job_display     = ( $job && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_job || $show_job ) ) ? $job : '';
-        $company_display = ( $company && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_comp || $show_comp ) ) ? $company : '';
-        if ( $job_display || $company_display ) :
-        ?>
-            <p class="pspa-graduate-title"><?php echo esc_html( trim( $job_display . ( $company_display ? ' - ' . $company_display : '' ) ) ); ?></p>
-        <?php endif; ?>
-        <?php if ( $profession && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_prof || $show_prof ) ) : ?>
-            <p class="pspa-graduate-profession"><?php echo esc_html( $profession ); ?></p>
-        <?php endif; ?>
-        <?php
-        $city_display    = ( $city && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_city || $show_city ) ) ? $city : '';
-        $country_display = ( $country && 'hide_all' !== $visibility && ( 'show_all' === $visibility || null === $show_country || $show_country ) ) ? $country : '';
-        if ( $city_display || $country_display ) :
-        ?>
-            <p class="pspa-graduate-location"><?php echo esc_html( trim( $city_display . ( $country_display ? ', ' . $country_display : '' ) ) ); ?></p>
-        <?php endif; ?>
-    </div>
-    <?php if ( function_exists( 'get_fields' ) && 'hide_all' !== $visibility ) : ?>
-        <div class="pspa-graduate-details">
-            <?php
-            $fields        = get_fields( 'user_' . $pspa_user->ID );
-            $header_fields = array(
-                'gn_job_title',
-                'gn_position_company',
-                'gn_profession',
-                'gn_city',
-                'gn_country',
-                'gn_profile_picture',
-            );
-            if ( $fields ) {
-                foreach ( $fields as $name => $value ) {
-                    if ( 'gn_visibility_mode' === $name || 0 === strpos( $name, 'gn_show_' ) ) {
-                        continue;
-                    }
-                    if ( in_array( $name, $header_fields, true ) ) {
-                        continue;
-                    }
-                    if ( 'show_all' !== $visibility ) {
-                        $show = function_exists( 'get_field' ) ? get_field( 'gn_show_' . $name, 'user_' . $pspa_user->ID ) : get_user_meta( $pspa_user->ID, 'gn_show_' . $name, true );
-                        if ( null !== $show && ! $show ) {
-                            continue;
-                        }
-                    }
-                    $field_obj = function_exists( 'acf_get_field' ) ? acf_get_field( $name ) : false;
-                    $label     = $field_obj ? $field_obj['label'] : $name;
-                    if ( is_bool( $value ) ) {
-                        if ( ! $value ) {
-                            continue;
-                        }
-                        printf(
-                            '<p class="pspa-graduate-field pspa-graduate-field-%1$s"><strong>%2$s</strong></p>',
-                            esc_attr( $name ),
-                            esc_html( $label )
-                        );
-                        continue;
-                    }
-                    if ( empty( $value ) ) {
-                        continue;
-                    }
-                    if ( is_array( $value ) ) {
-                        $value = implode( ', ', array_map( 'strval', array_filter( $value ) ) );
-                    }
-                    printf(
-                        '<p class="pspa-graduate-field pspa-graduate-field-%1$s"><strong>%2$s:</strong> %3$s</p>',
-                        esc_attr( $name ),
-                        esc_html( $label ),
-                        esc_html( $value )
-                    );
-                }
-            }
-            ?>
-        </div>
-    <?php endif; ?>
+    <?php
+    if ( function_exists( 'acf_form' ) ) {
+        acf_form( array(
+            'post_id'      => 'user_' . $pspa_user->ID,
+            'form'         => false,
+            'field_groups' => array( 'group_gn_graduate_profile' ),
+        ) );
+    }
+    ?>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var container = document.querySelector('.pspa-graduate-profile');
+    if (!container) {
+        return;
+    }
+    container.querySelectorAll('input, select, textarea, button').forEach(function(el) {
+        el.setAttribute('disabled', 'disabled');
+    });
+    container.querySelectorAll('.acf-actions').forEach(function(el){
+        el.remove();
+    });
+});
+</script>
 <?php
+remove_filter( 'acf/prepare_field', $prepare_field );
 get_footer();
+


### PR DESCRIPTION
## Summary
- Display public graduate profiles with the same dashboard layout as the My Account graduate profile endpoint, but with fields disabled
- Hide profile fields based on individual visibility settings
- Bump plugin version to 0.0.19

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc67d8eb24832792b0f10bcad469b3