### PR TITLE
Use LinkedIn-style layout for public graduate profiles

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.18
+ * Version: 0.0.20
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.18' );
+define( 'PSPA_MS_VERSION', '0.0.20' );
 
 /**
  * Enqueue shared dashboard styles.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.18
+Stable tag: 0.0.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,12 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.20 =
+* Display public graduate profiles in a LinkedIn-style layout and show visible fields even when empty.
+
+= 0.0.19 =
+* Render public graduate profiles using the dashboard layout in read-only mode.
+
 = 0.0.18 =
 * Ensure public graduate profile displays all ACF fields reliably.
 


### PR DESCRIPTION
## Summary
- Render public graduate profiles in a LinkedIn-style layout with header and sections
- Show empty values for fields the graduate marked as visible
- Bump plugin version to 0.0.20

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc67d8eb24832792b0f10bcad469b3