### PR TITLE
Add logging admin page and bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pspa-ms.log

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.22
+Stable tag: 0.0.23
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.23 =
+* Add logging and admin page for debugging login-by-details.
 = 0.0.22 =
 * Improve graduate public profile styling and remove visibility settings section.
 = 0.0.21 =


### PR DESCRIPTION
## Summary
- log login-by-details attempts and outcomes
- add admin page to review plugin log
- bump plugin version to 0.0.23

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd802dc03483279c6762583d3e3f86