### PR TITLE
Allow sysadmin profile edits and show empty ACF fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin powers the PSPA membership system and integrates with WooCommerce an
 The plugin registers two custom user roles:
 
 - **Professional Catalogue** (`professionalcatalogue`)
-- **System Admin** (`system-admin`)
+- **System Admin** (`system-admin` or `sysadmin`)
 
 ## Graduate Profile Dashboard
 
@@ -18,6 +18,7 @@ Key features:
  - **Per-field visibility toggles** – graduates can decide which profile fields are publicly visible.
  - **ACF-based form** – all profile fields are rendered using ACF Pro, with tabs hidden to keep the form on one page.
  - **Profile image uploads** – graduates are granted the `upload_files` capability to change their profile photo.
+ - **Password updates** – graduates can change their account password.
  - **Name synchronization** – the user's WordPress first name, last name and display name are updated after saving the form.
 - **WooCommerce integration** – registers a custom endpoint and navigation item under "My Account" so graduates can access the dashboard.
 - **Global visibility mode lock** – the `gn_visibility_mode` field is hidden on the front end and cannot be changed by graduates.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.27
+Stable tag: 0.0.28
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,7 +17,7 @@ Note: Versions prior to 0.0.25 processed the login form inside the shortcode aft
 The plugin registers two custom user roles:
 
 * Professional Catalogue (`professionalcatalogue`)
-* System Admin (`system-admin`)
+* System Admin (`system-admin` or `sysadmin`)
 
 == Installation ==
 1. Upload `pspa-membership-system` to the `/wp-content/plugins/` directory.
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.28 =
+* Recognize the `sysadmin` role and grant it the graduate editing dashboard.
+* Show all ACF fields to system administrators and catalogue editors, disabling required validation so empty fields can be filled later.
+* Bump version to 0.0.28.
+
 = 0.0.27 =
 * Allow System Admins and Professional Catalogue users to edit all graduate profile fields using the unified interface.
 * Let graduates update their password from the front-end profile form.


### PR DESCRIPTION
## Summary
- Permit `sysadmin` role to use the graduate editing dashboard and handle logins/redirects like other admins
- Remove ACF validation and conditional logic for admin editors so empty fields can be populated later
- Document new capabilities and bump plugin version to 0.0.28

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ea8a7548327a4751567cc4c2c94