### PR TITLE
Fix admin graduate profile edit URL and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.28
+ * Version: 0.0.29
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.28' );
+define( 'PSPA_MS_VERSION', '0.0.29' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -382,8 +382,9 @@ function pspa_ms_admin_profile_interface() {
         if ( ! empty( $user_ids ) ) {
             echo '<ul class="pspa-user-search-results">';
             foreach ( $user_ids as $id ) {
-                $u = get_user_by( 'id', $id );
-                echo '<li><a href="' . esc_url( add_query_arg( 'edit_user', $id ) ) . '">' . esc_html( $u->display_name . ' (' . $u->user_email . ')' ) . '</a></li>';
+                $u        = get_user_by( 'id', $id );
+                $edit_url = add_query_arg( 'edit_user', $id, wc_get_account_endpoint_url( 'graduate-profile' ) );
+                echo '<li><a href="' . esc_url( $edit_url ) . '">' . esc_html( $u->display_name . ' (' . $u->user_email . ')' ) . '</a></li>';
             }
             echo '</ul>';
         } else {
@@ -438,7 +439,8 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
     }
 
     echo '<div class="pspa-dashboard pspa-admin-edit-user">';
-    echo '<p><a href="' . esc_url( remove_query_arg( 'edit_user' ) ) . '">&larr; ' . esc_html__( 'Επιστροφή στην αναζήτηση', 'pspa-membership-system' ) . '</a></p>';
+    $search_url = wc_get_account_endpoint_url( 'graduate-profile' );
+    echo '<p><a href="' . esc_url( $search_url ) . '">&larr; ' . esc_html__( 'Επιστροφή στην αναζήτηση', 'pspa-membership-system' ) . '</a></p>';
 
     ?>
     <form method="post">

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.28
+Stable tag: 0.0.29
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.29 =
+* Ensure admin profile edit links always point to the My Account graduate profile endpoint.
+* Bump version to 0.0.29.
+
 = 0.0.28 =
 * Recognize the `sysadmin` role and grant it the graduate editing dashboard.
 * Show all ACF fields to system administrators and catalogue editors, disabling required validation so empty fields can be filled later.


### PR DESCRIPTION
## Summary
- ensure admin user search links point to the My Account `graduate-profile` endpoint
- update admin edit form back link to use consistent endpoint
- bump plugin version to 0.0.29

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bda31ec8e48327a2292b107853c6f5