### PR TITLE
Style WooCommerce account navigation

### DIFF
--- a/assets/css/woocommerce-navigation.css
+++ b/assets/css/woocommerce-navigation.css
@@ -1,0 +1,23 @@
+.woocommerce-account .woocommerce-MyAccount-navigation ul {
+    list-style: none;
+    margin: 0 0 20px;
+    padding: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li {
+    background: #fffaf5;
+    border: 1px solid #e4d6c8;
+    border-radius: 10px;
+    margin-bottom: 8px;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a {
+    display: block;
+    padding: 8px 12px;
+    color: #3b2b22;
+    text-decoration: none;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li.is-active a {
+    font-weight: 600;
+}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.29
+ * Version: 0.0.30
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.29' );
+define( 'PSPA_MS_VERSION', '0.0.30' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -39,6 +39,23 @@ function pspa_ms_enqueue_dashboard_styles() {
         PSPA_MS_VERSION
     );
 }
+
+/**
+ * Enqueue styles for the WooCommerce account navigation.
+ */
+function pspa_ms_enqueue_woocommerce_nav_styles() {
+    if ( ! function_exists( 'is_account_page' ) || ! is_account_page() ) {
+        return;
+    }
+
+    wp_enqueue_style(
+        'pspa-ms-woocommerce-nav',
+        plugin_dir_url( __FILE__ ) . 'assets/css/woocommerce-navigation.css',
+        array(),
+        PSPA_MS_VERSION
+    );
+}
+add_action( 'wp_enqueue_scripts', 'pspa_ms_enqueue_woocommerce_nav_styles' );
 
 /**
  * Ensure required plugins are active.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.29
+Stable tag: 0.0.30
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.30 =
+* Style WooCommerce account navigation to match the dashboard.
+* Bump version to 0.0.30.
+
 = 0.0.29 =
 * Ensure admin profile edit links always point to the My Account graduate profile endpoint.
 * Bump version to 0.0.29.


### PR DESCRIPTION
## Summary
- style default WooCommerce account navigation to match dashboard aesthetics
- load navigation styles on account endpoints
- bump plugin version to 0.0.30

## Testing
- `php -l pspa-membership-system.php`
- `phpcs -q --severity=1 pspa-membership-system.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda4e5ca148327bc5cecce8e0aa013