### PR TITLE
Display editable graduate cards in admin search

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -8,7 +8,6 @@
 .pspa-dashboard select,
 .pspa-dashboard textarea{width:100%;background:#fff;border:1px solid var(--line);border-radius:10px;padding:10px 12px}
 .pspa-admin-dashboard{max-width:600px;margin:0 auto}
-.pspa-user-search-results{list-style:none;margin:0;padding:0}
-.pspa-user-search-results li{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:8px 12px;margin-bottom:8px}
+.pspa-user-search-results{margin:0;padding:0}
 .pspa-admin-edit-user .form-row{margin-bottom:12px}
 .pspa-admin-edit-user label{display:block;margin-bottom:4px;color:var(--ink);font-weight:600}

--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -21,7 +21,6 @@
     padding: 1em;
     margin-bottom: 1em;
     background: #fff;
-    text-decoration: none;
     color: inherit;
 }
 
@@ -37,13 +36,23 @@
     margin: 0.2em 0;
 }
 
-.pspa-graduate-more {
-    display: inline-block;
+.pspa-graduate-actions {
     margin-top: 0.5em;
+    display: flex;
+    gap: 0.5em;
+}
+
+.pspa-graduate-actions a,
+.pspa-graduate-more {
     padding: 0.4em 0.8em;
     background: var(--ink, #3b2b22);
     color: #fff;
     border-radius: 4px;
+    text-decoration: none;
+}
+
+.pspa-graduate-edit {
+    background: #555;
 }
 
 .pspa-dir-pagination {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.1 =
+* Show system admin search results with graduate card layout.
+* Add edit button to graduate cards for administrators and system admins.
+* Bump version to 1.0.1.
 = 1.0.0 =
 * Cache filter options to reduce database queries.
 * Align login-by-details form styling with other dashboard forms.


### PR DESCRIPTION
## Summary
- Render system admin search results using the graduate card layout
- Add edit button on graduate directory cards for administrators and system admins
- Bump plugin version to 1.0.1

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa1b47b0832781da0f3ac96c83eb