### PR TITLE
Add paginated admin search with autocomplete

### DIFF
--- a/assets/js/admin-user-search.js
+++ b/assets/js/admin-user-search.js
@@ -1,0 +1,14 @@
+jQuery(function($){
+    var $input = $('#pspa_user_search');
+    if ($input.length){
+        $input.autocomplete({
+            source: function(request, response){
+                $.getJSON(pspaMsAdminSearch.ajaxUrl, {
+                    action: 'pspa_ms_user_autocomplete',
+                    nonce: pspaMsAdminSearch.nonce,
+                    term: request.term
+                }, response);
+            }
+        });
+    }
+});

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.2 =
+* Load first 12 users with pagination on the system admin dashboard.
+* Add autocomplete to the graduate search box.
+* Bump version to 1.0.2.
 = 1.0.1 =
 * Show system admin search results with graduate card layout.
 * Add edit button to graduate cards for administrators and system admins.


### PR DESCRIPTION
## Summary
- show first 12 users with pagination on sysadmin graduate-profile dashboard
- add autocomplete suggestions to admin user search field
- bump plugin version to 1.0.2

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdad52560883278d29f854dee113a1