### PR TITLE
Improve admin autocomplete search and bump version

### DIFF
--- a/assets/js/admin-user-search.js
+++ b/assets/js/admin-user-search.js
@@ -2,6 +2,7 @@ jQuery(function($){
     var $input = $('#pspa_user_search');
     if ($input.length){
         $input.autocomplete({
+            minLength: 3,
             source: function(request, response){
                 $.getJSON(pspaMsAdminSearch.ajaxUrl, {
                     action: 'pspa_ms_user_autocomplete',

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '1.0.3' );
+define( 'PSPA_MS_VERSION', '1.0.4' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -1009,9 +1009,18 @@ function pspa_ms_ajax_user_autocomplete() {
 
     $term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
 
+    if ( strlen( $term ) < 3 ) {
+        wp_send_json( array() );
+    }
+
     global $wpdb;
     $like          = '%' . $wpdb->esc_like( $term ) . '%';
-    $meta_user_ids = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT user_id FROM {$wpdb->usermeta} WHERE meta_value LIKE %s", $like ) );
+    $meta_user_ids = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT DISTINCT user_id FROM {$wpdb->usermeta} WHERE meta_key NOT LIKE '\\_%' AND meta_value LIKE %s",
+            $like
+        )
+    );
 
     $field_user_ids = get_users(
         array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.4 =
+* Start admin autocomplete after typing 3 characters.
+* Search includes graduate profile and ACF fields.
+* Bump version to 1.0.4.
 = 1.0.3 =
 * Expand admin search autocomplete to match ACF profile fields.
 * Bump version to 1.0.3.


### PR DESCRIPTION
## Summary
- Delay admin autocomplete until three characters are typed for fewer queries
- Search across all graduate profile and ACF fields and ignore underscored meta keys
- Bump plugin version to 1.0.4

## Testing
- `php -l pspa-membership-system.php`
- `node --check assets/js/admin-user-search.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb1ca42a48327a3df5284c91ffcfa