### PR TITLE
Use ACF fields for graduate names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.5 =
+* Display graduate names using ACF first and surname fields.
+* Sync WordPress name fields with ACF values and update display name.
+* Bump version to 1.0.5.
 = 1.0.4 =
 * Start admin autocomplete after typing 3 characters.
 * Search includes graduate profile and ACF fields.


### PR DESCRIPTION
## Summary
- Display graduate names using ACF first and surname fields
- Sync WordPress name fields with ACF values when editing users
- Bump plugin to version 1.0.5

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb4d800988327886336c8a328ae0a