### PR TITLE
Optimize graduate card rendering and sanitize slug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.6 =
+* Cache graduate cards to reduce repeated field lookups.
+* Sanitize public profile slugs to prevent invalid requests.
+* Bump version to 1.0.6.
 = 1.0.5 =
 * Display graduate names using ACF first and surname fields.
 * Sync WordPress name fields with ACF values and update display name.


### PR DESCRIPTION
## Summary
- cache graduate card output and consolidate field retrieval for faster rendering
- sanitize public profile slug before lookup to avoid invalid requests
- bump plugin version to 1.0.6 and document changes

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdb7504e4c8327b7ed60bad4e1243d