### PR TITLE
feat: reposition graduate profile nav item

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 1.0.6
+ * Version: 1.0.7
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '1.0.6' );
+define( 'PSPA_MS_VERSION', '1.0.7' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -142,8 +142,19 @@ add_filter( 'query_vars', 'pspa_ms_graduate_profile_query_vars' );
  * @return array
  */
 function pspa_ms_add_graduate_profile_link( $items ) {
-    $items['graduate-profile'] = __( 'Προφίλ Απόφοιτου', 'pspa-membership-system' );
-    return $items;
+    $new_items = array();
+    $index     = 0;
+
+    foreach ( $items as $key => $label ) {
+        if ( 1 === $index ) {
+            $new_items['graduate-profile'] = __( 'Προφίλ Απόφοιτου', 'pspa-membership-system' );
+        }
+
+        $new_items[ $key ] = $label;
+        $index++;
+    }
+
+    return $new_items;
 }
 add_filter( 'woocommerce_account_menu_items', 'pspa_ms_add_graduate_profile_link' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.7 =
+* Move Graduate Profile endpoint to second My Account menu position.
+* Bump version to 1.0.7.
 = 1.0.6 =
 * Cache graduate cards to reduce repeated field lookups.
 * Sanitize public profile slugs to prevent invalid requests.


### PR DESCRIPTION
## Summary
- place graduate-profile endpoint second in WooCommerce account navigation
- bump plugin version to 1.0.7

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb928c72c8327b2f80929f2acaa3d