### PR TITLE
Enable GitHub release updates and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '1.0.7' );
+define( 'PSPA_MS_VERSION', '1.0.8' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -114,6 +114,9 @@ $pspa_update_checker = PucFactory::buildUpdateChecker(
 
 // Optional: set the branch to check for updates.
 $pspa_update_checker->setBranch( 'main' );
+
+// Use release assets from the public GitHub repository for updates.
+$pspa_update_checker->getVcsApi()->enableReleaseAssets();
 
 /**
  * Register the Graduate Profile endpoint.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.8 =
+* Enable automatic updates using public GitHub release assets.
+* Bump version to 1.0.8.
 = 1.0.7 =
 * Move Graduate Profile endpoint to second My Account menu position.
 * Bump version to 1.0.7.


### PR DESCRIPTION
## Summary
- enable release asset support for public GitHub updates
- bump plugin version to 1.0.8 and document changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdba1257088327b4d8084e6f1cc508