### PR TITLE
chore: update repo URL and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 1.0.9
+ * Version: 1.0.10
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '1.0.9' );
+define( 'PSPA_MS_VERSION', '1.0.10' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -107,7 +107,7 @@ use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 // Initialize the update checker.
 $pspa_update_checker = PucFactory::buildUpdateChecker(
-    'https://github.com/PSPA/pspa-membership-system/',
+    'https://github.com/GeorgeWebDevCy/pspa-membership-system/',
     __FILE__,
     'pspa-membership-system'
 );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.9
+Stable tag: 1.0.10
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.10 =
+* Update GitHub repository URL for automatic updates.
+
 = 1.0.9 =
 * Bump version to 1.0.9 for automatic update testing.
 


### PR DESCRIPTION
## Summary
- point update checker to new GitHub repository
- bump plugin version to 1.0.10 and document change

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdbcf58ba88327a42382f9ea0aa4f5