### PR TITLE
Standardize E-mail spelling and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The plugin registers a **Graduate Profile** field group in Advanced Custom Field
 - **Εμφάνιση στο δημόσιο προφίλ: Φωτογραφία προφίλ** (`gn_show_profile_picture`, true_false)
 
 ### Επικοινωνία
-- **e-Mail** (`gn_email`, email)
-- **Εμφάνιση στο δημόσιο προφίλ: e-Mail** (`gn_show_email`, true_false)
+ - **E-mail** (`gn_email`, email)
+ - **Εμφάνιση στο δημόσιο προφίλ: E-mail** (`gn_show_email`, true_false)
 - **Κινητό** (`gn_mobile`, text)
 - **Εμφάνιση στο δημόσιο προφίλ: Κινητό** (`gn_show_mobile`, true_false)
 - **Τηλ. Εργασίας** (`gn_work_phone`, text)

--- a/acf-export-2025-09-06-with-profile.json
+++ b/acf-export-2025-09-06-with-profile.json
@@ -328,7 +328,7 @@
       },
       {
         "key": "field_gn_email",
-        "label": "e-Mail",
+        "label": "E-mail",
         "name": "gn_email",
         "aria-label": "",
         "type": "email",
@@ -347,7 +347,7 @@
       },
       {
         "key": "field_gn_show_email",
-        "label": "Εμφάνιση στο δημόσιο προφίλ: e-Mail",
+        "label": "Εμφάνιση στο δημόσιο προφίλ: E-mail",
         "name": "gn_show_email",
         "aria-label": "",
         "type": "true_false",

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 1.0.11
+ * Version: 1.0.12
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '1.0.11' );
+define( 'PSPA_MS_VERSION', '1.0.12' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.11
+Stable tag: 1.0.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.12 =
+* Standardize "E-mail" capitalization.
+
 = 1.0.11 =
 * Bump version to 1.0.11 for automatic update testing.
 


### PR DESCRIPTION
## Summary
- Replace `e-Mail` references with `E-mail` across documentation and ACF export
- Bump plugin version to 1.0.12 and update changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdc015ab4c8327bd841b80b6647ae1