### PR TITLE
Restrict graduate directory access

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.12
+Stable tag: 1.0.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,8 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 1.0.13 =
+* Restrict graduate directory access to the `/επαγγελματικός-κατάλογος/` page and redirect other views to the profile editor.
 = 1.0.12 =
 * Standardize "E-mail" capitalization.
 


### PR DESCRIPTION
## Summary
- Redirect graduates trying to view the directory outside `/επαγγελματικός-κατάλογος/` to their profile editor
- Bump plugin version to 1.0.13

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdc74d84088327b071f142ce2f4239