### PR TITLE
Restrict catalogue graduates from admin search

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.30
+ * Version: 0.0.31
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.30' );
+define( 'PSPA_MS_VERSION', '0.0.31' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -242,8 +242,7 @@ function pspa_ms_unrestrict_acf_fields_for_admins( $field ) {
     if (
         current_user_can( 'manage_options' ) ||
         in_array( 'system-admin', $roles, true ) ||
-        in_array( 'sysadmin', $roles, true ) ||
-        in_array( 'professionalcatalogue', $roles, true )
+        in_array( 'sysadmin', $roles, true )
     ) {
         $field['required']          = 0;
         $field['conditional_logic'] = 0;
@@ -284,8 +283,7 @@ function pspa_ms_graduate_profile_content() {
     if (
         current_user_can( 'manage_options' ) ||
         in_array( 'system-admin', (array) $current_user->roles, true ) ||
-        in_array( 'sysadmin', (array) $current_user->roles, true ) ||
-        in_array( 'professionalcatalogue', (array) $current_user->roles, true )
+        in_array( 'sysadmin', (array) $current_user->roles, true )
     ) {
         pspa_ms_admin_profile_interface();
         return;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.30
+Stable tag: 0.0.31
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.31 =
+* Restrict catalogue graduates from accessing the admin search interface.
+* Bump version to 0.0.31.
+
 = 0.0.30 =
 * Style WooCommerce account navigation to match the dashboard.
 * Bump version to 0.0.30.


### PR DESCRIPTION
## Summary
- prevent `professionalcatalogue` graduates from viewing admin search interface
- bump plugin version to 0.0.31

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd21784e08327904825b36c6b7220