### PR TITLE
feat: card layout for admin search

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dependencies:
 
 ## Administrator Tools
 
-System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, email and password controls. The interface uses the same `pspa-dashboard` styles as the graduate profile for a consistent appearance.
+System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, email and password controls. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. The interface uses the same `pspa-dashboard` styles as the graduate profile for a consistent appearance.
 
 ## Login by Details
 
@@ -41,7 +41,7 @@ The `[pspa_login_by_details]` shortcode renders a form asking for first name, la
 
 ## Graduate Directory
 
-The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking a card or the "Δείτε Περισσότερο" link opens the graduate's public, non-editable profile. Public profiles are also accessible directly at `/graduate/<username>/`.
+The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking "Δείτε Περισσότερο" opens the graduate's public, non-editable profile. When logged in as an administrator or System Admin, cards also show an "Επεξεργασία" link to jump directly to the editing interface. Public profiles are also accessible directly at `/graduate/<username>/`.
 
 ## Role-based Redirection
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.31
+Stable tag: 0.0.32
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.32 =
+* Render admin search results using the graduate card layout and expose an edit link on cards for administrators.
+* Bump version to 0.0.32.
+
 = 0.0.31 =
 * Restrict catalogue graduates from accessing the admin search interface.
 * Bump version to 0.0.31.


### PR DESCRIPTION
## Summary
- use graduate directory card layout for admin search results
- allow admins to jump from directory cards to editing users
- bump version to 0.0.32

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4d9764883278a395d630f1d6ff1