### PR TITLE
fix: update repository URL and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.32
+ * Version: 0.0.33
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.32' );
+define( 'PSPA_MS_VERSION', '0.0.33' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -107,7 +107,7 @@ use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 // Initialize the update checker.
 $pspa_update_checker = PucFactory::buildUpdateChecker(
-    'https://github.com/PSPA/pspa-membership-system/',
+    'https://github.com/GeorgeWebDevCy/pspa-membership-system/',
     __FILE__,
     'pspa-membership-system'
 );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.32
+Stable tag: 0.0.33
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.33 =
+* Fix update checker to use the new GitHub repository.
+* Bump version to 0.0.33.
+
 = 0.0.32 =
 * Render admin search results using the graduate card layout and expose an edit link on cards for administrators.
 * Bump version to 0.0.32.


### PR DESCRIPTION
## Summary
- point update checker to GeorgeWebDevCy repository
- bump plugin version to 0.0.33

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd7fbe9bc8327a6e9ef10f09a7c6a