### PR TITLE
Standardize E-mail wording and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dependencies:
 
 ## Administrator Tools
 
-System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, email and password controls. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. The interface uses the same `pspa-dashboard` styles as the graduate profile for a consistent appearance.
+System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, E-mail and password controls. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. The interface uses the same `pspa-dashboard` styles as the graduate profile for a consistent appearance.
 
 ## Login by Details
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.33
+ * Version: 0.0.34
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.33' );
+define( 'PSPA_MS_VERSION', '0.0.34' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -338,7 +338,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
             ) ); ?>
         <?php endif; ?>
         <p class="form-row form-row-wide">
-            <label for="email"><?php esc_html_e( 'Διεύθυνση email', 'pspa-membership-system' ); ?></label>
+            <label for="email"><?php esc_html_e( 'Διεύθυνση E-mail', 'pspa-membership-system' ); ?></label>
             <input type="email" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
         </p>
         <p class="form-row form-row-wide">
@@ -467,7 +467,7 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
             <input type="text" name="last_name" id="last_name" value="<?php echo esc_attr( $user->last_name ); ?>" />
         </p>
         <p class="form-row form-row-wide">
-            <label for="email"><?php esc_html_e( 'Διεύθυνση email', 'pspa-membership-system' ); ?></label>
+            <label for="email"><?php esc_html_e( 'Διεύθυνση E-mail', 'pspa-membership-system' ); ?></label>
             <input type="email" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
         </p>
         <p class="form-row form-row-wide">

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.33
+Stable tag: 0.0.34
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.34 =
+* Standardize "E-mail" capitalization.
+* Bump version to 0.0.34.
+
 = 0.0.33 =
 * Fix update checker to use the new GitHub repository.
 * Bump version to 0.0.33.


### PR DESCRIPTION
## Summary
- standardize "E-mail" spelling across user-facing strings and docs
- bump plugin version to 0.0.34

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd8b35cb48327a69a0983175e3565