### PR TITLE
Move graduate profile endpoint in account navigation

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.34
+ * Version: 0.0.35
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.34' );
+define( 'PSPA_MS_VERSION', '0.0.35' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -142,8 +142,10 @@ add_filter( 'query_vars', 'pspa_ms_graduate_profile_query_vars' );
  * @return array
  */
 function pspa_ms_add_graduate_profile_link( $items ) {
-    $items['graduate-profile'] = __( 'Προφίλ Απόφοιτου', 'pspa-membership-system' );
-    return $items;
+    $profile = array( 'graduate-profile' => __( 'Προφίλ Απόφοιτου', 'pspa-membership-system' ) );
+    $first  = array_slice( $items, 0, 1, true );
+    $rest   = array_slice( $items, 1, null, true );
+    return $first + $profile + $rest;
 }
 add_filter( 'woocommerce_account_menu_items', 'pspa_ms_add_graduate_profile_link' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.34
+Stable tag: 0.0.35
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.35 =
+* Move graduate profile endpoint to second position in account navigation.
+* Bump version to 0.0.35.
+
 = 0.0.34 =
 * Standardize "E-mail" capitalization.
 * Bump version to 0.0.34.


### PR DESCRIPTION
## Summary
- insert the Graduate Profile endpoint as second item in WooCommerce account navigation
- bump plugin version to 0.0.35 and update changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd9db6100832781b2361bb2f5220e