### PR TITLE
Use ACF name fields for user names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.35
+Stable tag: 0.0.36
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.36 =
+* Use ACF first and last name fields for displaying user names.
+* Synchronize WordPress name fields with ACF values.
+* Bump version to 0.0.36.
+
 = 0.0.35 =
 * Move graduate profile endpoint to second position in account navigation.
 * Bump version to 0.0.35.


### PR DESCRIPTION
## Summary
- display graduate names using ACF first and last name fields
- sync WordPress name fields with ACF values after profile edits
- bump plugin version to 0.0.36

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdda91402c8327a9f7903745173b69