### PR TITLE
Add full name and graduation year filters to directory

### DIFF
--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -10,7 +10,8 @@
     margin-bottom: 1em;
 }
 
-#pspa-graduate-filters select {
+#pspa-graduate-filters select,
+#pspa-graduate-filters input {
     min-width: 150px;
 }
 

--- a/assets/js/graduate-directory.js
+++ b/assets/js/graduate-directory.js
@@ -9,6 +9,8 @@ jQuery(function($){
             job_title: $('#pspa-graduate-filters [name="job_title"]').val(),
             city: $('#pspa-graduate-filters [name="city"]').val(),
             country: $('#pspa-graduate-filters [name="country"]').val(),
+            graduation_year: $('#pspa-graduate-filters [name="graduation_year"]').val(),
+            full_name: $('#pspa-graduate-filters [name="full_name"]').val(),
             page: currentPage
         };
         $.post(pspaMsDir.ajaxUrl, data, function(response){
@@ -19,6 +21,11 @@ jQuery(function($){
     }
 
     $('#pspa-graduate-filters').on('change', 'select', function(){
+        currentPage = 1;
+        fetchGraduates();
+    });
+
+    $('#pspa-graduate-filters [name="full_name"]').on('input', function(){
         currentPage = 1;
         fetchGraduates();
     });

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.36
+Stable tag: 0.0.37
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.37 =
+* Add full name and graduation year filters to the Graduate Directory.
+* Give administrators the same directory interface for searching.
+* Bump version to 0.0.37.
+
 = 0.0.36 =
 * Use ACF first and last name fields for displaying user names.
 * Synchronize WordPress name fields with ACF values.


### PR DESCRIPTION
## Summary
- allow searching graduates by full name and graduation year
- reuse graduate directory interface for administrator search
- bump plugin version to 0.0.37

## Testing
- `php -l pspa-membership-system.php`
- `node --check assets/js/graduate-directory.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfed2acc8327a8aeeaedfd3d36aa