### PR TITLE
Use text input for graduation year filter

### DIFF
--- a/assets/js/graduate-directory.js
+++ b/assets/js/graduate-directory.js
@@ -25,7 +25,7 @@ jQuery(function($){
         fetchGraduates();
     });
 
-    $('#pspa-graduate-filters [name="full_name"]').on('input', function(){
+    $('#pspa-graduate-filters [name="full_name"], #pspa-graduate-filters [name="graduation_year"]').on('input', function(){
         currentPage = 1;
         fetchGraduates();
     });

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.37
+ * Version: 0.0.38
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.37' );
+define( 'PSPA_MS_VERSION', '0.0.38' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -779,19 +779,13 @@ function pspa_ms_graduate_directory_shortcode() {
     $jobs        = pspa_ms_get_unique_user_meta_values( 'gn_job_title' );
     $cities      = pspa_ms_get_unique_user_meta_values( 'gn_city' );
     $countries   = pspa_ms_get_unique_user_meta_values( 'gn_country' );
-    $years       = pspa_ms_get_unique_user_meta_values( 'gn_graduation_year' );
 
     ob_start();
     ?>
     <div class="pspa-graduate-directory pspa-dashboard">
         <form id="pspa-graduate-filters">
             <input type="text" name="full_name" placeholder="<?php esc_attr_e( 'Πλήρες Όνομα', 'pspa-membership-system' ); ?>" />
-            <select name="graduation_year">
-                <option value=""><?php esc_html_e( 'Όλα τα Έτη', 'pspa-membership-system' ); ?></option>
-                <?php foreach ( $years as $y ) : ?>
-                    <option value="<?php echo esc_attr( $y ); ?>"><?php echo esc_html( $y ); ?></option>
-                <?php endforeach; ?>
-            </select>
+            <input type="text" name="graduation_year" placeholder="<?php esc_attr_e( 'Έτος Αποφοίτησης', 'pspa-membership-system' ); ?>" />
             <select name="profession">
                 <option value=""><?php esc_html_e( 'Όλα τα Επαγγέλματα', 'pspa-membership-system' ); ?></option>
                 <?php foreach ( $professions as $p ) : ?>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.37
+Stable tag: 0.0.38
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.38 =
+* Make graduation year filter a text field.
+* Bump version to 0.0.38.
+
 = 0.0.37 =
 * Add full name and graduation year filters to the Graduate Directory.
 * Give administrators the same directory interface for searching.


### PR DESCRIPTION
## Summary
- allow typing graduation year directly in the Graduate Directory filter
- bump plugin version to 0.0.38

## Testing
- `php -l pspa-membership-system.php`
- `node --check assets/js/graduate-directory.js`


------
https://chatgpt.com/codex/tasks/task_e_68bde2d6b53c8327ba2ebcf8c4d7b3cf