### PR TITLE
Fix full name filter and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.39
+ * Version: 0.0.40
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.39' );
+define( 'PSPA_MS_VERSION', '0.0.40' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -846,15 +846,6 @@ function pspa_ms_ajax_filter_graduates() {
         }
     }
 
-    $page      = isset( $_POST['page'] ) ? max( 1, absint( $_POST['page'] ) ) : 1;
-    $per_page  = 50;
-    $args      = array(
-        'number'     => $per_page,
-        'offset'     => ( $page - 1 ) * $per_page,
-        'meta_query' => $meta_query,
-        'count_total'=> true,
-    );
-
     if ( ! empty( $_POST['full_name'] ) ) {
         $full_name = sanitize_text_field( wp_unslash( $_POST['full_name'] ) );
         $parts     = preg_split( '/\s+/', $full_name, 2 );
@@ -890,6 +881,15 @@ function pspa_ms_ajax_filter_graduates() {
 
         $meta_query[] = $name_query;
     }
+
+    $page     = isset( $_POST['page'] ) ? max( 1, absint( $_POST['page'] ) ) : 1;
+    $per_page = 50;
+    $args     = array(
+        'number'     => $per_page,
+        'offset'     => ( $page - 1 ) * $per_page,
+        'meta_query' => $meta_query,
+        'count_total'=> true,
+    );
 
     $users       = new WP_User_Query( $args );
     $total_users = (int) $users->get_total();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.39
+Stable tag: 0.0.40
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.40 =
+* Ensure full name filter applies to graduate directory searches.
+* Bump version to 0.0.40.
+
 = 0.0.39 =
 * Search full name using ACF first and surname fields.
 * Bump version to 0.0.39.


### PR DESCRIPTION
## Summary
- fix graduate directory full name filter so search value is respected
- bump plugin version to 0.0.40

## Testing
- `php -l pspa-membership-system.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde782b9fc8327b9df017d7cafb847