### PR TITLE
fix: ensure exact full name search for system admins

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.41
+ * Version: 0.0.42
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.41' );
+define( 'PSPA_MS_VERSION', '0.0.42' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -867,15 +867,25 @@ function pspa_ms_ajax_filter_graduates() {
                 ),
             );
         } else {
+            $compare      = 'LIKE';
+            $current_user = wp_get_current_user();
+            if (
+                current_user_can( 'manage_options' ) ||
+                in_array( 'system-admin', (array) $current_user->roles, true ) ||
+                in_array( 'sysadmin', (array) $current_user->roles, true )
+            ) {
+                $compare = '=';
+            }
+
             $name_query[] = array(
                 'key'     => 'gn_first_name',
                 'value'   => $full_name,
-                'compare' => 'LIKE',
+                'compare' => $compare,
             );
             $name_query[] = array(
                 'key'     => 'gn_surname',
                 'value'   => $full_name,
-                'compare' => 'LIKE',
+                'compare' => $compare,
             );
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.41
+Stable tag: 0.0.42
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.42 =
+* Match single-name searches exactly for System Admins while retaining Unicode support.
+* Bump version to 0.0.42.
 = 0.0.41 =
 * Match searches for full names against the ACF first name and surname fields with multibyte (e.g. Greek) character support.
 * Bump version to 0.0.41.


### PR DESCRIPTION
## Summary
- ensure system-admin directory searches use exact name matching with Unicode support
- bump plugin version to 0.0.42

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdee6516388327932e299f03520f44