### PR TITLE
Improve login-by-details matching and authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The `[pspa_login_by_details]` shortcode renders a form asking for first name, la
 
 > **Note:** In versions prior to 0.0.25 the login logic ran inside the shortcode after page output had begun, so WordPress could not send the authentication cookie and the user remained logged out. The processing now runs on `template_redirect` before headers are sent, and extra logging records the user's status. Version 0.0.24 also ensured the cookie respects the current SSL state.
 
+Starting with version 0.0.44 names are compared case-insensitively and the authentication cookie is set before establishing the current user. Earlier versions queried user meta with case-sensitive comparisons and set the current user before the cookie, which caused valid submissions (e.g. with different letter casing) to fail or leave the user unauthenticated after a successful lookup.
+
 ## Graduate Directory
 
 The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking "Δείτε Περισσότερο" opens the graduate's public, non-editable profile. When logged in as an administrator or System Admin, cards also show an "Επεξεργασία" link to jump directly to the editing interface. Public profiles are also accessible directly at `/graduate/<username>/`.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.43
+Stable tag: 0.0.44
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.44 =
+* Match login-by-details submissions case-insensitively and fix login process.
+* Add extra logging around login-by-details.
+* Bump version to 0.0.44.
+
 = 0.0.43 =
 * Allow full name searches to match first or last names individually.
 * Bump version to 0.0.43.


### PR DESCRIPTION
## Summary
- Normalize name comparisons for login-by-details so the lookup is case-insensitive
- Fix login-by-details authentication flow and add additional status logging
- Document login-by-details behaviour and bump plugin version to 0.0.44

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68be8ea9ff4c8327afdd1bc3bf29fcb1