### PR TITLE
Normalize Greek full name comparison for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `[pspa_login_by_details]` shortcode renders a form asking for first name, la
 
 > **Note:** In versions prior to 0.0.25 the login logic ran inside the shortcode after page output had begun, so WordPress could not send the authentication cookie and the user remained logged out. The processing now runs on `template_redirect` before headers are sent, and extra logging records the user's status. Version 0.0.24 also ensured the cookie respects the current SSL state.
 
-Starting with version 0.0.44 names are compared case-insensitively and the authentication cookie is set before establishing the current user. Earlier versions queried user meta with case-sensitive comparisons and set the current user before the cookie, which caused valid submissions (e.g. with different letter casing) to fail or leave the user unauthenticated after a successful lookup.
+Starting with version 0.0.45 names are matched case- and accent-insensitively by combining the ACF first name and surname fields into a full name string. Earlier versions compared each field separately and only ignored casing, which caused valid submissions with tonal differences (e.g. Ιωάννης vs ΙΩΑΝΝΗΣ) to fail.
 
 ## Graduate Directory
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.44
+Stable tag: 0.0.45
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.45 =
+* Normalize full name from ACF first name and surname fields for flexible, accent-insensitive login-by-details matching.
+* Bump version to 0.0.45.
+
 = 0.0.44 =
 * Match login-by-details submissions case-insensitively and fix login process.
 * Add extra logging around login-by-details.


### PR DESCRIPTION
## Summary
- Normalize Greek characters to allow case- and accent-insensitive matching when logging in by details
- Compare login submissions against concatenated ACF first name and surname fields
- Bump plugin version to 0.0.45

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68be93491a848327be97e436cfa2a8ce