### PR TITLE
Add auto-incrementing initial DB ID field

### DIFF
--- a/acf-export-2025-09-06-with-profile.json
+++ b/acf-export-2025-09-06-with-profile.json
@@ -22,6 +22,30 @@
         "selected": 0
       },
       {
+        "key": "field_gn_initial_db_id",
+        "label": "Initial DB ID",
+        "name": "gn_initial_db_id",
+        "aria-label": "",
+        "type": "number",
+        "instructions": "",
+        "required": false,
+        "conditional_logic": false,
+        "wrapper": {
+          "width": "50",
+          "class": "",
+          "id": ""
+        },
+        "default_value": "",
+        "min": "",
+        "max": "",
+        "step": "",
+        "placeholder": "",
+        "prepend": "",
+        "append": "",
+        "readonly": 1,
+        "disabled": 1
+      },
+      {
         "key": "field_gn_surname",
         "label": "Επώνυμο",
         "name": "gn_surname",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.45
+Stable tag: 0.0.46
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.46 =
+* Add auto-incrementing Initial DB ID field and lock it from edits.
+* Bump version to 0.0.46.
+
 = 0.0.45 =
 * Normalize full name from ACF first name and surname fields for flexible, accent-insensitive login-by-details matching.
 * Bump version to 0.0.45.


### PR DESCRIPTION
## Summary
- add read-only `gn_initial_db_id` ACF field
- auto-assign sequential Initial DB ID to new users
- lock Initial DB ID from edits in ACF forms
- bump plugin version to 0.0.46

## Testing
- `jq empty acf-export-2025-09-06-with-profile.json`
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5272ceb5c83279044bdf30a57c89a