### PR TITLE
Add admin user creation interface and bump version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.47
+Stable tag: 0.0.48
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.48 =
+* Add admin interface for creating users.
+* Bump version to 0.0.48.
+
 = 0.0.47 =
 * Record login-by-details verification date and block repeated use.
 * Bump version to 0.0.47.


### PR DESCRIPTION
## Summary
- allow administrators and system admins to create users from the dashboard
- expose new form styled like existing ACF-based interfaces
- bump plugin version to 0.0.48

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68c53398058c8327bd4db14dd035b267