### PR TITLE
Add admin reset button and bump version to 0.0.50

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.48
+Stable tag: 0.0.50
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,14 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+= 0.0.50 =
+* Add admin button to reset plugin settings.
+* Bump version to 0.0.50.
+
+= 0.0.49 =
+* Add WP-CLI command to reset plugin settings.
+* Bump version to 0.0.49.
+
 = 0.0.48 =
 * Add admin interface for creating users.
 * Bump version to 0.0.48.


### PR DESCRIPTION
## Summary
- add admin logs page button to reset plugin settings
- add `pspa-ms reset` WP-CLI command to clear plugin options
- bump plugin version to 0.0.50

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c564d6b5648327abceb1ea4ec4b401