### PR TITLE
Fix login-by-details redirect and bump version to 0.0.51

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.50
+Stable tag: 0.0.51
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.51 =
+* Fix Login By Details redirect to the Graduate Profile dashboard.
+* Bump version to 0.0.51.
 = 0.0.50 =
 * Add admin button to reset plugin settings.
 * Bump version to 0.0.50.


### PR DESCRIPTION
## Summary
- ensure Login By Details redirects to Graduate Profile dashboard using a dedicated URL helper
- replace direct `wc_get_account_endpoint_url` calls with helper
- bump plugin version to 0.0.51 and update changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce2b33848327a22c086a940d49a7