### PR TITLE
Add SweetAlert notice for verified login-by-details users

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.51
+Stable tag: 0.0.52
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.52 =
+* Show alert with email when login-by-details user already verified.
+* Bump version to 0.0.52.
 
 = 0.0.51 =
 * Fix Login By Details redirect to the Graduate Profile dashboard.


### PR DESCRIPTION
## Summary
- Notify users attempting login-by-details who are already verified via a SweetAlert2 popup that shows their email and suggests logging in or resetting password
- Pass matched email through redirect and load SweetAlert2 from CDN
- Bump plugin version to 0.0.52 with changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5d17828808327a7f670d4eed0d73e