### PR TITLE
Add paid members admin tab

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.54
+Stable tag: 0.0.55
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.55 =
+* Add tab for administrators listing users who purchased this year.
+* Bump version to 0.0.55.
 
 = 0.0.54 =
 * Redirect Login By Details to the user's Graduate Profile edit page.


### PR DESCRIPTION
## Summary
- allow admins and system admins to view a Paid Members tab listing users with orders in the current year
- register new `paid-members` endpoint and render list on My Account
- bump plugin version to 0.0.55

## Testing
- `php -l pspa-membership-system.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6612693b88327872da930f51d9e7d