### PR TITLE
Style Login by Details form with dashboard colors and bump version

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -9,5 +9,6 @@
 .pspa-dashboard textarea{width:100%;background:#fff;border:1px solid var(--line);border-radius:10px;padding:10px 12px}
 .pspa-admin-dashboard{max-width:600px;margin:0 auto}
 .pspa-user-search-results{margin:0;padding:0}
-.pspa-admin-edit-user .form-row{margin-bottom:12px}
-.pspa-admin-edit-user label{display:block;margin-bottom:4px;color:var(--ink);font-weight:600}
+.pspa-dashboard .form-row{margin-bottom:12px}
+.pspa-dashboard label{display:block;margin-bottom:4px;color:var(--ink);font-weight:600}
+.pspa-dashboard .woocommerce-Button.button{background:var(--ink);color:#fff;border-radius:10px;padding:10px 15px}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.55
+ * Version: 0.0.56
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.55' );
+define( 'PSPA_MS_VERSION', '0.0.56' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.55
+Stable tag: 0.0.56
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.56 =
+* Apply dashboard styling to Login By Details form.
+* Bump version to 0.0.56.
 
 = 0.0.55 =
 * Add tab for administrators listing users who purchased this year.


### PR DESCRIPTION
## Summary
- Apply dashboard styling to Login By Details form for consistent spacing, labels, and button colors.
- Bump plugin version to 0.0.56 and update documentation.

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c666123d9883279f303fc0e87a3a92