### PR TITLE
Hide admin-only ACF fields for catalogue editors

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.56
+ * Version: 0.0.57
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.56' );
+define( 'PSPA_MS_VERSION', '0.0.57' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -404,6 +404,41 @@ function pspa_ms_hide_public_visibility_toggles( $field ) {
     return $field;
 }
 add_filter( 'acf/prepare_field', 'pspa_ms_hide_public_visibility_toggles', 20 );
+
+/**
+ * Hide admin-only fields from catalogue editors and graduate profile forms.
+ *
+ * @param array|false $field Field settings.
+ * @return array|false
+ */
+function pspa_ms_hide_admin_only_fields( $field ) {
+    if ( ! is_array( $field ) ) {
+        return $field;
+    }
+
+    $admin_only = array(
+        'gn_initial_db_id',
+        'gn_login_verified_date',
+        'gn_deceased',
+        'gn_show_deceased',
+    );
+
+    if ( ! in_array( $field['name'], $admin_only, true ) ) {
+        return $field;
+    }
+
+    $current_user = wp_get_current_user();
+    $roles        = (array) $current_user->roles;
+    $is_catalogue = in_array( 'professionalcatalogue', $roles, true );
+    $is_grad_form = function_exists( 'is_account_page' ) && is_account_page() && false !== get_query_var( 'graduate-profile', false );
+
+    if ( $is_catalogue || $is_grad_form ) {
+        return false;
+    }
+
+    return $field;
+}
+add_filter( 'acf/prepare_field', 'pspa_ms_hide_admin_only_fields', 30 );
 
 /**
  * Render Graduate Profile endpoint content.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.56
+Stable tag: 0.0.57
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.57 =
+* Hide admin-only ACF fields from catalogue editors and graduate profile forms.
+* Bump version to 0.0.57.
 
 = 0.0.56 =
 * Apply dashboard styling to Login By Details form.


### PR DESCRIPTION
## Summary
- Hide "Initial DB ID", "Login Verified Date", and deceased-related fields for `professionalcatalogue` users and on graduate profile forms
- Bump plugin version to 0.0.57

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6316c848327a552b5214c95045c