### PR TITLE
Delay login verification until user saves credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ System Admins and site administrators can search for graduates and edit any user
 
 ## Login by Details
 
-The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard. The first successful login records the date in a read-only `gn_login_verified_date` field and subsequent attempts are blocked.
+The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard. The verification date is stored in the read-only `gn_login_verified_date` field only after the user sets an email and password via the profile form; once saved, subsequent login-by-details attempts are blocked.
 
 > **Note:** In versions prior to 0.0.25 the login logic ran inside the shortcode after page output had begun, so WordPress could not send the authentication cookie and the user remained logged out. The processing now runs on `template_redirect` before headers are sent, and extra logging records the user's status. Version 0.0.24 also ensured the cookie respects the current SSL state.
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.57
+ * Version: 0.0.58
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.57' );
+define( 'PSPA_MS_VERSION', '0.0.58' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -490,8 +490,14 @@ function pspa_ms_simple_profile_form( $user_id ) {
             $update_data['user_pass'] = $password;
         }
 
+        $updated = false;
         if ( count( $update_data ) > 1 ) {
-            wp_update_user( $update_data );
+            $result  = wp_update_user( $update_data );
+            $updated = ! is_wp_error( $result );
+        }
+
+        if ( $updated && ! get_user_meta( $user_id, 'gn_login_verified_date', true ) && ! empty( $email ) && ! empty( $password ) ) {
+            update_user_meta( $user_id, 'gn_login_verified_date', current_time( 'mysql' ) );
         }
 
         if ( function_exists( 'pspa_ms_sync_user_names' ) ) {
@@ -785,9 +791,6 @@ function pspa_ms_handle_login_by_details() {
             wp_set_current_user( $user->ID, $user->user_login );
             if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
                 wc_set_customer_auth_cookie( $user->ID );
-            }
-            if ( ! get_user_meta( $user->ID, 'gn_login_verified_date', true ) ) {
-                update_user_meta( $user->ID, 'gn_login_verified_date', current_time( 'mysql' ) );
             }
             pspa_ms_log( 'User logged in status after auth cookie: ' . ( is_user_logged_in() ? 'true' : 'false' ) );
             do_action( 'wp_login', $user->user_login, $user );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.57
+Stable tag: 0.0.58
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.58 =
+* Delay setting login-by-details verification date until the user saves email and password.
+* Bump version to 0.0.58.
 
 = 0.0.57 =
 * Hide admin-only ACF fields from catalogue editors and graduate profile forms.


### PR DESCRIPTION
## Summary
- defer login-by-details verification until the user saves email and password
- document new login verification flow
- bump plugin version to 0.0.58

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6cb3e794483279f50e56508647343