### PR TITLE
Defer verification until email and password saved

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.58
+Stable tag: 0.0.59
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.59 =
+* Require both email and password before recording verification date.
+* Bump version to 0.0.59.
 
 = 0.0.58 =
 * Delay setting login-by-details verification date until the user saves email and password.


### PR DESCRIPTION
## Summary
- Only record verification date after profile update succeeds with both email and password
- Handle update errors and require existing email before setting verification date
- Bump plugin version to 0.0.59

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68c6ce92d2c883278a4f13b16e7ddd67