### PR TITLE
Verify user after profile update when email or password set

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.60
+ * Version: 0.0.61
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.60' );
+define( 'PSPA_MS_VERSION', '0.0.61' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -516,16 +516,16 @@ function pspa_ms_simple_profile_form( $user_id ) {
             pspa_ms_log( 'No profile fields updated for user ' . $user_id );
         }
 
-        if ( $updated && ! get_user_meta( $user_id, 'gn_login_verified_date', true ) && '' !== $password ) {
+        if ( $updated && ! get_user_meta( $user_id, 'gn_login_verified_date', true ) ) {
             $fresh = get_user_by( 'id', $user_id );
-            if ( $fresh && ! empty( $fresh->user_email ) ) {
+            if ( $fresh && ! empty( $fresh->user_email ) && ! empty( $fresh->user_pass ) ) {
                 update_user_meta( $user_id, 'gn_login_verified_date', current_time( 'mysql' ) );
                 pspa_ms_log( 'Verification date recorded for user ' . $user_id );
-            } else {
+            } elseif ( $fresh && empty( $fresh->user_email ) ) {
                 pspa_ms_log( 'Verification date not set for user ' . $user_id . ': missing email after update' );
+            } else {
+                pspa_ms_log( 'Verification date not set for user ' . $user_id . ': missing password after update' );
             }
-        } elseif ( '' === $password ) {
-            pspa_ms_log( 'Verification date not set for user ' . $user_id . ': password missing' );
         }
 
         if ( $updated && function_exists( 'pspa_ms_sync_user_names' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.60
+Stable tag: 0.0.61
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.61 =
+* Record verification date once a profile update leaves the user with both email and password.
+* Bump version to 0.0.61.
 
 = 0.0.60 =
 * Add detailed logging for profile updates to troubleshoot password update failures.


### PR DESCRIPTION
## Summary
- verify user after profile update whenever both email and password exist
- bump PSPA Membership System plugin version to 0.0.61

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6d368581083278eacefc11fd8d6fc