### PR TITLE
Verify user after password update and log profile changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ System Admins and site administrators can search for graduates and edit any user
 
 ## Login by Details
 
-The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard. The verification date is stored in the read-only `gn_login_verified_date` field only after the user sets an email and password via the profile form; once saved, subsequent login-by-details attempts are blocked.
+The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard. The verification date is stored in the read-only `gn_login_verified_date` field after a profile update saves a password and an email address already exists; once saved, subsequent login-by-details attempts are blocked.
 
 > **Note:** In versions prior to 0.0.25 the login logic ran inside the shortcode after page output had begun, so WordPress could not send the authentication cookie and the user remained logged out. The processing now runs on `template_redirect` before headers are sent, and extra logging records the user's status. Version 0.0.24 also ensured the cookie respects the current SSL state.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.60
+Stable tag: 0.0.62
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,14 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.62 =
+* Save password changes reliably and log profile update attempts.
+* Set verification date when a password is saved and an email already exists.
+* Bump version to 0.0.62.
+
+= 0.0.61 =
+* Record verification date once a profile update leaves the user with both email and password.
 
 = 0.0.60 =
 * Add detailed logging for profile updates to troubleshoot password update failures.


### PR DESCRIPTION
## Summary
- ensure password changes are saved and logged
- set verification date when saving a password and an email already exists
- bump PSPA Membership System plugin version to 0.0.62

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6d368581083278eacefc11fd8d6fc