### PR TITLE
Fix admin profile password updates and add logging

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.61
+Stable tag: 0.0.62
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.62 =
+* Log admin profile update attempts and handle failures when updating passwords.
+* Bump version to 0.0.62.
 
 = 0.0.61 =
 * Record verification date once a profile update leaves the user with both email and password.


### PR DESCRIPTION
## Summary
- log admin profile update attempts and handle failures
- avoid empty email updates blocking password changes
- bump plugin version to 0.0.62

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8ba3f7c83278fb2c638b64f0b18