### PR TITLE
Fix password update on graduate profile

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.62
+Stable tag: 0.0.63
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.63 =
+* Fix password updates when saving the Graduate Profile form.
+* Bump version to 0.0.63.
 
 = 0.0.62 =
 * Log admin profile update attempts and handle failures when updating passwords.


### PR DESCRIPTION
## Summary
- ensure Graduate Profile form updates user passwords using `wp_set_password`
- keep user logged in after password change and log update
- bump plugin version to 0.0.63

## Testing
- `php -l pspa-membership-system.php`

------
https://chatgpt.com/codex/tasks/task_e_68c6dc1e80208327b6c699d3f19425dd