### PR TITLE
Add verbose logging for login and profile updates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.63
+Stable tag: 0.0.64
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.64 =
+* Add verbose logging for login-by-details and profile updates.
+* Bump version to 0.0.64.
 
 = 0.0.63 =
 * Fix password updates when saving the Graduate Profile form.


### PR DESCRIPTION
## Summary
- add detailed logging around login-by-details submissions and profile updates
- log nonce validation, SQL queries, user meta, and authentication steps for debugging
- bump plugin version to 0.0.64

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6e0567e648327a5b16060811c62d4