### PR TITLE
Fix password update fatal error and bump version to 0.0.66

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.65
+ * Version: 0.0.66
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.65' );
+define( 'PSPA_MS_VERSION', '0.0.66' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -547,18 +547,6 @@ function pspa_ms_simple_profile_form( $user_id ) {
                 }
                 pspa_ms_log( 'Password updated for user ' . $user_id );
                 $updated = true;
-            wp_set_password( $password, $user_id );
-            $fresh_pass = get_user_by( 'id', $user_id );
-            pspa_ms_log( 'New password hash prefix for user ' . $user_id . ': ' . substr( $fresh_pass->user_pass, 0, 10 ) );
-            wp_set_auth_cookie( $user_id, true, is_ssl() );
-            pspa_ms_log( 'Auth cookie refreshed for user ' . $user_id );
-            wp_set_current_user( $user_id, $user->user_login );
-            pspa_ms_log( 'is_user_logged_in after password set: ' . ( is_user_logged_in() ? 'true' : 'false' ) );
-            if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
-                wc_set_customer_auth_cookie( $user_id );
-                pspa_ms_log( 'wc_set_customer_auth_cookie called for user ' . $user_id );
-            } else {
-                pspa_ms_log( 'wc_set_customer_auth_cookie unavailable' );
             }
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.65
+Stable tag: 0.0.66
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.66 =
+* Fix fatal error caused by unmatched braces in profile password update logic.
+* Bump version to 0.0.66.
 
 = 0.0.65 =
 * Use `wp_update_user` for password changes and log failures.


### PR DESCRIPTION
## Summary
- fix unmatched braces that caused fatal error in profile form password update
- bump plugin version to 0.0.66

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6e515bd788327bc7ed1addd862de2