### PR TITLE
Add show/hide toggle for password fields

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -12,3 +12,5 @@
 .pspa-dashboard .form-row{margin-bottom:12px}
 .pspa-dashboard label{display:block;margin-bottom:4px;color:var(--ink);font-weight:600}
 .pspa-dashboard .woocommerce-Button.button{background:var(--ink);color:#fff;border-radius:10px;padding:10px 15px}
+.pspa-dashboard .password-input{position:relative;display:block}
+.pspa-dashboard .password-input .show-password-input{color:var(--ink)}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.67
+ * Version: 0.0.68
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.67' );
+define( 'PSPA_MS_VERSION', '0.0.68' );
 
 define( 'PSPA_MS_LOG_FILE', plugin_dir_path( __FILE__ ) . 'pspa-ms.log' );
 
@@ -589,7 +589,10 @@ function pspa_ms_simple_profile_form( $user_id ) {
         </p>
         <p class="form-row form-row-wide">
             <label for="password"><?php esc_html_e( 'Νέος κωδικός', 'pspa-membership-system' ); ?></label>
-            <input type="password" name="password" id="password" autocomplete="new-password" />
+            <span class="password-input">
+                <input class="woocommerce-Input woocommerce-Input--text input-text" type="password" name="password" id="password" autocomplete="new-password" />
+                <button type="button" class="show-password-input" aria-label="<?php esc_attr_e( 'Εμφάνιση συνθηματικού', 'pspa-membership-system' ); ?>" aria-describedby="password"></button>
+            </span>
         </p>
         <?php wp_nonce_field( 'pspa_graduate_profile', 'pspa_graduate_profile_nonce' ); ?>
         <p>
@@ -721,7 +724,10 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
         </p>
         <p class="form-row form-row-wide">
             <label for="password"><?php esc_html_e( 'Νέος κωδικός', 'pspa-membership-system' ); ?></label>
-            <input type="password" name="password" id="password" autocomplete="new-password" />
+            <span class="password-input">
+                <input class="woocommerce-Input woocommerce-Input--text input-text" type="password" name="password" id="password" autocomplete="new-password" />
+                <button type="button" class="show-password-input" aria-label="<?php esc_attr_e( 'Εμφάνιση συνθηματικού', 'pspa-membership-system' ); ?>" aria-describedby="password"></button>
+            </span>
         </p>
         <?php wp_nonce_field( 'pspa_admin_edit_user', 'pspa_admin_edit_user_nonce' ); ?>
         <p>
@@ -797,7 +803,10 @@ function pspa_ms_admin_add_user_form() {
         </p>
         <p class="form-row form-row-wide">
             <label for="password"><?php esc_html_e( 'Κωδικός', 'pspa-membership-system' ); ?></label>
-            <input type="password" name="password" id="password" autocomplete="new-password" />
+            <span class="password-input">
+                <input class="woocommerce-Input woocommerce-Input--text input-text" type="password" name="password" id="password" autocomplete="new-password" />
+                <button type="button" class="show-password-input" aria-label="<?php esc_attr_e( 'Εμφάνιση συνθηματικού', 'pspa-membership-system' ); ?>" aria-describedby="password"></button>
+            </span>
         </p>
         <?php wp_nonce_field( 'pspa_admin_add_user', 'pspa_admin_add_user_nonce' ); ?>
         <p>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.67
+Stable tag: 0.0.68
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.68 =
+* Add show/hide toggle to password fields while preserving dashboard colors.
+* Bump version to 0.0.68.
 
 = 0.0.67 =
 * Ensure password changes save reliably by using `wp_set_password` and verifying the update.


### PR DESCRIPTION
## Summary
- add WooCommerce-style show/hide toggle to password fields
- preserve dashboard colors for password toggle
- bump plugin version to 0.0.68 and update changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea7dc9ac8327828b79a2d8e2295c