### PR TITLE
Update login verification date on credential changes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.68
+Stable tag: 0.0.69
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.69 =
+* Update login verification date when email or password changes.
+* Bump version to 0.0.69.
 
 = 0.0.68 =
 * Add show/hide toggle to password fields while preserving dashboard colors.


### PR DESCRIPTION
## Summary
- Refresh `gn_login_verified_date` whenever the user's email or password is updated and log the change.
- Bump plugin version to 0.0.69.

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed7d6fac8327ab85768996970e3e