### PR TITLE
Add password strength meter and restore legacy logging

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -14,3 +14,7 @@
 .pspa-dashboard .woocommerce-Button.button{background:var(--ink);color:#fff;border-radius:10px;padding:10px 15px}
 .pspa-dashboard .password-input{position:relative;display:block}
 .pspa-dashboard .password-input .show-password-input{color:var(--ink)}
+.pspa-dashboard .password-strength{margin-top:4px;padding:5px;border:1px solid var(--line);border-radius:10px;text-align:center;background:#eee;color:var(--ink)}
+.pspa-dashboard .password-strength.short,.pspa-dashboard .password-strength.bad{background:#ffb78c;border-color:#ff853c}
+.pspa-dashboard .password-strength.good{background:#ffec8b;border-color:#e6db55}
+.pspa-dashboard .password-strength.strong{background:#c1e1b9;border-color:#83c373}

--- a/assets/js/password-strength.js
+++ b/assets/js/password-strength.js
@@ -1,0 +1,30 @@
+jQuery(function($){
+    function updateStrength($input,$meter){
+        var val = $input.val();
+        var strength = wp.passwordStrength.meter(val, wp.passwordStrength.userInputBlacklist(), val);
+        var cls = 'short';
+        var text = pwsL10n.short;
+        switch(strength){
+            case 2:
+                cls = 'bad';
+                text = pwsL10n.bad;
+                break;
+            case 3:
+                cls = 'good';
+                text = pwsL10n.good;
+                break;
+            case 4:
+                cls = 'strong';
+                text = pwsL10n.strong;
+                break;
+        }
+        $meter.removeClass('short bad good strong').addClass(cls).text(text);
+    }
+
+    $('.password-input input[type="password"]').each(function(){
+        var $input = $(this);
+        var $meter = $('<div class="password-strength"></div>');
+        $input.after($meter);
+        $input.on('keyup', function(){ updateStrength($input, $meter); });
+    });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.72
+Stable tag: 0.0.73
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.73 =
+* Add password strength indicator to profile forms.
+* Revert to option-based logging system.
 
 = 0.0.72 =
 * Log messages only when debugging is enabled.


### PR DESCRIPTION
## Summary
- add JS-driven password strength meter on profile forms
- revert logging to option-based storage with admin viewer
- bump plugin version to 0.0.73

## Testing
- `php -l pspa-membership-system.php`
- `node --check assets/js/password-strength.js`


------
https://chatgpt.com/codex/tasks/task_e_68c70028cb00832796ca0c04631c5a8d