### PR TITLE
Log profile update input and password strength

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.73
+Stable tag: 0.0.74
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.74 =
+* Reduce logging noise when updating graduate profiles and record entered data, password strength and WordPress errors.
+* Remove duplicate password toggle from profile forms.
 
 = 0.0.73 =
 * Add password strength indicator to profile forms.


### PR DESCRIPTION
## Summary
- record entered email and password strength when graduate profiles are updated
- report WordPress errors during email/password updates and avoid duplicate password toggles
- bump plugin version to 0.0.74

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7038dbfec8327b90eb3bdfe10f4f2