### PR TITLE
Use wp_set_password for password updates

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.77
+ * Version: 0.0.78
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.77' );
+define( 'PSPA_MS_VERSION', '0.0.78' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -587,24 +587,16 @@ function pspa_ms_simple_profile_form( $user_id ) {
         }
 
         if ( ! empty( $password ) ) {
-            $result = wp_update_user( array(
-                'ID'        => $user_id,
-                'user_pass' => $password,
-            ) );
-
-            if ( is_wp_error( $result ) ) {
-                pspa_ms_log( 'Password update failed for user ' . $user_id . ': ' . implode( '; ', $result->get_error_messages() ) );
-                wc_add_notice( __( 'Δεν ήταν δυνατή η ενημέρωση του κωδικού.', 'pspa-membership-system' ), 'error' );
-            } else {
-                wp_set_current_user( $user_id, $user->user_login );
-                wp_set_auth_cookie( $user_id, true, is_ssl() );
-                if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
-                    wc_set_customer_auth_cookie( $user_id );
-                }
-                pspa_ms_log( 'Password updated for user ' . $user_id );
-                $password_updated = true;
-                $updated          = true;
+            pspa_ms_log( 'Bypassing capabilities to set password for user ' . $user_id );
+            wp_set_password( $password, $user_id );
+            wp_set_current_user( $user_id, $user->user_login );
+            wp_set_auth_cookie( $user_id, true, is_ssl() );
+            if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
+                wc_set_customer_auth_cookie( $user_id );
             }
+            pspa_ms_log( 'Password updated for user ' . $user_id );
+            $password_updated = true;
+            $updated          = true;
         }
 
         if ( $email_updated || $password_updated ) {
@@ -730,18 +722,10 @@ function pspa_ms_admin_edit_user_form( $user_id ) {
         }
 
         if ( ! empty( $password ) ) {
-            $result = wp_update_user( array(
-                'ID'        => $user_id,
-                'user_pass' => $password,
-            ) );
-
-            if ( is_wp_error( $result ) ) {
-                pspa_ms_log( 'Admin password update failed for user ' . $user_id . ': ' . implode( '; ', $result->get_error_messages() ) );
-                wc_add_notice( __( 'Δεν ήταν δυνατή η ενημέρωση του κωδικού.', 'pspa-membership-system' ), 'error' );
-            } else {
-                pspa_ms_log( 'Admin password updated for user ' . $user_id );
-                $updated = true;
-            }
+            pspa_ms_log( 'Admin bypassing capabilities to set password for user ' . $user_id );
+            wp_set_password( $password, $user_id );
+            pspa_ms_log( 'Admin password updated for user ' . $user_id );
+            $updated = true;
         }
 
         if ( $updated ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.77
+Stable tag: 0.0.78
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.78 =
+* Bypass capability checks when updating passwords by using `wp_set_password` and keep graduates logged in.
 
 = 0.0.77 =
 * Remove verbose function argument logging.


### PR DESCRIPTION
## Summary
- Replace `wp_update_user` with `wp_set_password` for graduate and admin password changes, bypassing capability checks and keeping users logged in
- Add logging around password updates and reauthentication
- Bump plugin version to 0.0.78 and update changelog

## Testing
- `php -l pspa-membership-system.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c70f420f048327bd20b0c9f2673190