### PR TITLE
Fix email update cache issue and bump version to 0.0.79

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.78
+ * Version: 0.0.79
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.78' );
+define( 'PSPA_MS_VERSION', '0.0.79' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -583,6 +583,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
                 $email_updated = true;
                 $updated       = true;
                 pspa_ms_log( 'Email updated for user ' . $user_id );
+                wp_set_current_user( $user_id );
             }
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.78
+Stable tag: 0.0.79
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.79 =
+* Refresh current user data after email changes so updates appear immediately.
 
 = 0.0.78 =
 * Bypass capability checks when updating passwords by using `wp_set_password` and keep graduates logged in.


### PR DESCRIPTION
## Summary
- ensure email changes immediately reflected by refreshing current user after update
- bump plugin version to 0.0.79

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c712c200a48327bf616d2f1e7ea618