### PR TITLE
Expose WooCommerce edit-account form for profile updates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.79
+Stable tag: 0.0.80
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.80 =
+* Display WooCommerce's account edit form to handle email and password updates.
 
 = 0.0.79 =
 * Refresh current user data after email changes so updates appear immediately.


### PR DESCRIPTION
## Summary
- show WooCommerce's default edit account form after the ACF-based graduate profile fields
- simplify graduate profile form handling and bump plugin version to 0.0.80

## Testing
- `php -l pspa-membership-system.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c715145ba88327a285328eb6eaf982