### PR TITLE
Expose WooCommerce edit-account form for profile updates

### DIFF
--- a/assets/js/edit-account-form.js
+++ b/assets/js/edit-account-form.js
@@ -1,0 +1,15 @@
+jQuery(function($){
+    var $form = $('.woocommerce-EditAccountForm.edit-account');
+    if (!$form.length) {
+        return;
+    }
+    // Hide name fields and current password field
+    $form.find('#account_first_name, #account_last_name, #account_display_name, #password_current').closest('p').hide();
+    // Add dashboard class for consistent styling
+    $form.addClass('pspa-dashboard');
+    // Update submit button text and ensure styling
+    var $button = $form.find('button[name="save_account_details"]');
+    $button.text('Αποθήκευση αλλαγών εισόδου');
+    $button.val('Αποθήκευση αλλαγών εισόδου');
+    $button.addClass('woocommerce-Button button');
+});

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.79
+ * Version: 0.0.81
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.79' );
+define( 'PSPA_MS_VERSION', '0.0.81' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -139,6 +139,26 @@ function pspa_ms_enqueue_password_strength() {
     );
 }
 add_action( 'wp_enqueue_scripts', 'pspa_ms_enqueue_password_strength' );
+
+/**
+ * Enqueue script to customize WooCommerce edit account form.
+ */
+function pspa_ms_enqueue_edit_account_customizations() {
+    if ( ! function_exists( 'is_account_page' ) || ! is_account_page() ) {
+        return;
+    }
+
+    if ( function_exists( 'is_wc_endpoint_url' ) && is_wc_endpoint_url( 'graduate-profile' ) ) {
+        wp_enqueue_script(
+            'pspa-ms-edit-account-form',
+            plugin_dir_url( __FILE__ ) . 'assets/js/edit-account-form.js',
+            array( 'jquery' ),
+            PSPA_MS_VERSION,
+            true
+        );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'pspa_ms_enqueue_edit_account_customizations' );
 
 /**
  * Estimate password strength for logging.
@@ -555,66 +575,14 @@ function pspa_ms_simple_profile_form( $user_id ) {
         isset( $_POST['pspa_graduate_profile_nonce'] ) &&
         wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['pspa_graduate_profile_nonce'] ) ), 'pspa_graduate_profile' )
     ) {
-        $email    = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
-        $password = isset( $_POST['password'] ) ? wp_unslash( $_POST['password'] ) : '';
-        $strength = $password ? pspa_ms_password_strength( $password ) : 'none';
+        pspa_ms_log( 'Graduate profile ACF form submitted for user ' . $user_id );
+        update_user_meta( $user_id, 'gn_login_verified_date', current_time( 'mysql' ) );
 
-        pspa_ms_log( sprintf(
-            'Graduate profile update for user %d: email="%s", password_strength="%s"',
-            $user_id,
-            $email ? $email : 'none',
-            $strength
-        ) );
-
-        $updated          = false;
-        $email_updated    = false;
-        $password_updated = false;
-
-        if ( ! empty( $email ) ) {
-            $result = wp_update_user( array(
-                'ID'         => $user_id,
-                'user_email' => $email,
-            ) );
-
-            if ( is_wp_error( $result ) ) {
-                pspa_ms_log( 'Email update failed for user ' . $user_id . ': ' . $result->get_error_message() );
-                wc_add_notice( $result->get_error_message(), 'error' );
-            } else {
-                $email_updated = true;
-                $updated       = true;
-                pspa_ms_log( 'Email updated for user ' . $user_id );
-                wp_set_current_user( $user_id );
-            }
-        }
-
-        if ( ! empty( $password ) ) {
-            pspa_ms_log( 'Bypassing capabilities to set password for user ' . $user_id );
-            wp_set_password( $password, $user_id );
-            wp_set_current_user( $user_id, $user->user_login );
-            wp_set_auth_cookie( $user_id, true, is_ssl() );
-            if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
-                wc_set_customer_auth_cookie( $user_id );
-            }
-            pspa_ms_log( 'Password updated for user ' . $user_id );
-            $password_updated = true;
-            $updated          = true;
-        }
-
-        if ( $email_updated || $password_updated ) {
-            update_user_meta( $user_id, 'gn_login_verified_date', current_time( 'mysql' ) );
-        }
-
-        if ( $updated && function_exists( 'pspa_ms_sync_user_names' ) ) {
+        if ( function_exists( 'pspa_ms_sync_user_names' ) ) {
             pspa_ms_sync_user_names( 'user_' . $user_id );
         }
 
-        if ( $updated ) {
-            wc_add_notice( __( 'Το προφίλ ενημερώθηκε με επιτυχία.', 'pspa-membership-system' ) );
-            $user = wp_get_current_user();
-            pspa_ms_log( 'Profile updated for user ' . $user_id );
-        } else {
-            pspa_ms_log( 'No profile fields updated for user ' . $user_id );
-        }
+        wc_add_notice( __( 'Το προφίλ ενημερώθηκε με επιτυχία.', 'pspa-membership-system' ) );
     }
 
     pspa_ms_enqueue_dashboard_styles();
@@ -627,16 +595,6 @@ function pspa_ms_simple_profile_form( $user_id ) {
                 'field_groups' => array( 'group_gn_graduate_profile' ),
             ) ); ?>
         <?php endif; ?>
-        <p class="form-row form-row-wide">
-            <label for="email"><?php esc_html_e( 'Διεύθυνση E-mail', 'pspa-membership-system' ); ?></label>
-            <input type="email" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
-        </p>
-        <p class="form-row form-row-wide">
-            <label for="password"><?php esc_html_e( 'Νέος κωδικός', 'pspa-membership-system' ); ?></label>
-            <span class="password-input">
-                <input class="woocommerce-Input woocommerce-Input--text input-text" type="password" name="password" id="password" autocomplete="new-password" />
-            </span>
-        </p>
         <?php wp_nonce_field( 'pspa_graduate_profile', 'pspa_graduate_profile_nonce' ); ?>
         <p>
             <button type="submit" class="woocommerce-Button button">
@@ -644,6 +602,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
             </button>
         </p>
     </form>
+    <?php do_action( 'woocommerce_account_edit-account_endpoint' ); ?>
     <?php
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.79
+Stable tag: 0.0.81
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,13 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.81 =
+* Hide personal name fields from WooCommerce's edit account form.
+* Rename and style the form's submit button for consistency.
+
+= 0.0.80 =
+* Display WooCommerce's account edit form to handle email and password updates.
 
 = 0.0.79 =
 * Refresh current user data after email changes so updates appear immediately.


### PR DESCRIPTION
## Summary
- show WooCommerce's default edit account form after the ACF-based graduate profile fields
- simplify graduate profile form handling and bump plugin version to 0.0.80
- hide personal name fields on the edit account form and restyle submit button

## Testing
- `php -l pspa-membership-system.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c715145ba88327a285328eb6eaf982