### PR TITLE
Hide edit account fields with CSS

### DIFF
--- a/assets/css/edit-account-form.css
+++ b/assets/css/edit-account-form.css
@@ -1,0 +1,32 @@
+.woocommerce-EditAccountForm fieldset p.woocommerce-form-row:first-of-type {
+    display: none !important;
+}
+
+input#account_first_name {
+    display: none !important;
+}
+
+p.woocommerce-form-row.woocommerce-form-row--first.form-row.form-row-first {
+    display: none !important;
+}
+
+input#account_last_name {
+    display: none !important;
+}
+
+p.woocommerce-form-row.woocommerce-form-row--last.form-row.form-row-last {
+    display: none !important;
+}
+
+input#account_display_name {
+    display: none !important;
+}
+
+span#account_display_name_description {
+    display: none !important;
+}
+
+label[for="account_display_name"] {
+    display: none !important;
+}
+

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.81
+ * Version: 0.0.82
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.81' );
+define( 'PSPA_MS_VERSION', '0.0.82' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -149,6 +149,13 @@ function pspa_ms_enqueue_edit_account_customizations() {
     }
 
     if ( function_exists( 'is_wc_endpoint_url' ) && is_wc_endpoint_url( 'graduate-profile' ) ) {
+        wp_enqueue_style(
+            'pspa-ms-edit-account-form',
+            plugin_dir_url( __FILE__ ) . 'assets/css/edit-account-form.css',
+            array(),
+            PSPA_MS_VERSION
+        );
+
         wp_enqueue_script(
             'pspa-ms-edit-account-form',
             plugin_dir_url( __FILE__ ) . 'assets/js/edit-account-form.js',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.81
+Stable tag: 0.0.82
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -31,6 +31,9 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 
 == Changelog ==
 
+
+= 0.0.82 =
+* Hide edit account fields using CSS to prevent a brief flash of content.
 
 = 0.0.81 =
 * Hide personal name fields from WooCommerce's edit account form.


### PR DESCRIPTION
## Summary
- Hide first name, last name, display name, and current password fields in WooCommerce's edit account form with a dedicated stylesheet
- Enqueue the stylesheet and bump plugin version to 0.0.82
- Document the change in the readme

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c71d3941088327bdced18555787a8a