### PR TITLE
Improve password update handling and verification date logic

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.83
+Stable tag: 0.0.84
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.84 =
+* Ensure password updates work for login-by-details users, logging outcomes and recording verification date when an email exists.
 
 = 0.0.83 =
 * Revert to code base 0.0.77.


### PR DESCRIPTION
## Summary
- add helper to update user passwords by ID, email, or username with logging
- use helper in profile forms and record verification date only when password changes and an email exists
- bump plugin version to 0.0.84 and update changelog

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7f4c5d5ac8327bed353502d95c3cb