### PR TITLE
Handle hidden ACF fields safely and bump version

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.84
+ * Version: 0.0.85
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.84' );
+define( 'PSPA_MS_VERSION', '0.0.85' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -507,12 +507,17 @@ add_filter( 'acf/prepare_field', 'pspa_ms_unrestrict_acf_fields_for_admins', 5 )
  * @return array|false
  */
 function pspa_ms_hide_public_visibility_toggles( $field ) {
+    if ( ! is_array( $field ) || empty( $field['name'] ) ) {
+        return $field;
+    }
+
     if ( 0 === strpos( $field['name'], 'gn_show_' ) ) {
         if ( function_exists( 'is_account_page' ) && is_account_page() && false !== get_query_var( 'graduate-profile', false ) ) {
             return $field;
         }
         return false;
     }
+
     return $field;
 }
 add_filter( 'acf/prepare_field', 'pspa_ms_hide_public_visibility_toggles', 20 );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.84
+Stable tag: 0.0.85
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.85 =
+* Prevent warnings when visibility filters receive a hidden field.
 
 = 0.0.84 =
 * Ensure password updates work for login-by-details users, logging outcomes and recording verification date when an email exists.


### PR DESCRIPTION
## Summary
- Avoid PHP warnings when ACF filters pass hidden fields
- Bump plugin version to 0.0.85

## Testing
- `php -l pspa-membership-system.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7fdd34ac883279e863e88b68e6d26