### PR TITLE
Remove credential inputs from graduate profile forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Key features:
  - **Per-field visibility toggles** – graduates can decide which profile fields are publicly visible.
  - **ACF-based form** – all profile fields are rendered using ACF Pro, with tabs hidden to keep the form on one page.
  - **Profile image uploads** – graduates are granted the `upload_files` capability to change their profile photo.
- - **Password updates** – graduates can change their account password.
+ - **Password updates** – the WooCommerce account details form appears above the profile so graduates can manage their credentials.
  - **Name synchronization** – the user's WordPress first name, last name and display name are updated after saving the form.
 - **WooCommerce integration** – registers a custom endpoint and navigation item under "My Account" so graduates can access the dashboard.
 - **Global visibility mode lock** – the `gn_visibility_mode` field is hidden on the front end and cannot be changed by graduates.
@@ -31,7 +31,7 @@ Dependencies:
 
 ## Administrator Tools
 
-System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form with ACF data, E-mail and password controls. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. The interface uses the same `pspa-dashboard` styles as the graduate profile for a consistent appearance.
+System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form that mirrors the ACF data graduates see. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. Credential changes should be handled via the WooCommerce account form or the WordPress user editor.
 
 ## Login by Details
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.86
+Stable tag: 0.0.87
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.87 =
+* Remove the email and password fields from graduate profile editing forms so only ACF fields are shown.
 
 = 0.0.86 =
 * Display the WooCommerce "Account details" form before the graduate profile and block profile editing until an email and password are saved.


### PR DESCRIPTION
## Summary
- remove the manual email/password inputs from both graduate and admin profile editors so the forms only expose the ACF fields
- add an ACF save handler that logs the update and displays the existing success notice after profile fields are saved
- update plugin documentation and bump the version to 0.0.87

## Testing
- php -l pspa-membership-system/pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca72b938ac83278224d0ad1f37520e