### PR TITLE
Preserve login failure query flag for SweetAlert popup

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.88
+Stable tag: 0.0.89
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.89 =
+* Preserve the `login-details` query flag to stop canonical redirects from hiding the login failure popup.
 
 = 0.0.88 =
 * Redirect already verified login-by-details submissions to the graduate profile dashboard.


### PR DESCRIPTION
## Summary
- prevent WordPress canonical redirects from stripping the `login-details` status so the login failure popup renders
- bump the plugin version metadata to 0.0.89 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca7c1943408327a444bff916a89304