### PR TITLE
Redirect login details failure to dedicated page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.89
+Stable tag: 0.0.90
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.90 =
+* Redirect `login-details=failed` requests to the "αποτυχία-επικαιροποίησης" page while preserving intentional canonical redirects.
 
 = 0.0.89 =
 * Preserve the `login-details` query flag to stop canonical redirects from hiding the login failure popup.


### PR DESCRIPTION
## Summary
- add a helper that exposes the login-by-details failure redirect URL and reuse it across the plugin
- allow canonical redirects to reach the failure page and send `login-details=failed` requests there automatically
- bump the plugin version to 0.0.90 and document the behavior change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca818c74588327a5e8a67fe7d4438a