### PR TITLE
Reorder edit account endpoint and bump version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.90
+Stable tag: 0.0.91
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.91 =
+* Place the WooCommerce Edit Account endpoint immediately after "My Account" in the account navigation.
 
 = 0.0.90 =
 * Redirect `login-details=failed` requests to the "αποτυχία-επικαιροποίησης" page while preserving intentional canonical redirects.


### PR DESCRIPTION
## Summary
- reorder the WooCommerce account menu so the Edit Account endpoint follows My Account before custom links
- keep the administrator-only Paid Members link positioned after the Graduate Profile item after the reorder
- bump the plugin version to 0.0.91 and update the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca84d67c9c8327949bf82cecbd6e8a