### PR TITLE
Ensure graduate save button posts save_account_details

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.91
+ * Version: 0.0.92
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.91' );
+define( 'PSPA_MS_VERSION', '0.0.92' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -694,7 +694,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
         <?php endif; ?>
         <?php wp_nonce_field( 'pspa_graduate_profile', 'pspa_graduate_profile_nonce' ); ?>
         <p>
-            <button type="submit" class="woocommerce-Button button">
+            <button type="submit" class="woocommerce-Button button" name="save_account_details" value="<?php esc_attr_e( 'Αποθήκευση αλλαγών', 'pspa-membership-system' ); ?>">
                 <?php esc_html_e( 'Αποθήκευση αλλαγών', 'pspa-membership-system' ); ?>
             </button>
         </p>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.91
+Stable tag: 0.0.92
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.92 =
+* Ensure graduate profile save buttons use the WooCommerce "save_account_details" markup so account updates trigger verification.
 
 = 0.0.91 =
 * Place the WooCommerce Edit Account endpoint immediately after "My Account" in the account navigation.


### PR DESCRIPTION
## Summary
- add the WooCommerce save_account_details attributes to the graduate profile save button so verification logic can run
- bump the plugin version to 0.0.92 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca870d0834832784ddd80ac12c90ae