### PR TITLE
Remove embedded edit account form from graduate profile endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Key features:
  - **Per-field visibility toggles** – graduates can decide which profile fields are publicly visible.
  - **ACF-based form** – all profile fields are rendered using ACF Pro, with tabs hidden to keep the form on one page.
  - **Profile image uploads** – graduates are granted the `upload_files` capability to change their profile photo.
- - **Password updates** – the WooCommerce account details form appears above the profile so graduates can manage their credentials.
+ - **Password updates** – graduates manage their credentials via the WooCommerce account details endpoint while keeping the profile form focused on ACF fields.
  - **Name synchronization** – the user's WordPress first name, last name and display name are updated after saving the form.
 - **WooCommerce integration** – registers a custom endpoint and navigation item under "My Account" so graduates can access the dashboard.
 - **Global visibility mode lock** – the `gn_visibility_mode` field is hidden on the front end and cannot be changed by graduates.

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.92
+ * Version: 0.0.93
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.92' );
+define( 'PSPA_MS_VERSION', '0.0.93' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -616,36 +616,9 @@ function pspa_ms_graduate_profile_content() {
         return;
     }
 
-    pspa_ms_render_edit_account_section( $current_user );
     pspa_ms_simple_profile_form( $current_user->ID );
 }
 add_action( 'woocommerce_account_graduate-profile_endpoint', 'pspa_ms_graduate_profile_content' );
-
-/**
- * Display the WooCommerce edit account form ahead of the graduate profile.
- *
- * @param WP_User $user Current user.
- */
-function pspa_ms_render_edit_account_section( $user ) {
-    if ( ! $user instanceof WP_User ) {
-        return;
-    }
-
-    pspa_ms_enqueue_dashboard_styles();
-
-    echo '<div class="pspa-dashboard pspa-account-details">';
-    echo '<h2>' . esc_html__( 'Στοιχεία λογαριασμού', 'pspa-membership-system' ) . '</h2>';
-
-    if ( class_exists( 'WC_Shortcode_My_Account' ) && method_exists( 'WC_Shortcode_My_Account', 'edit_account' ) ) {
-        WC_Shortcode_My_Account::edit_account();
-    } elseif ( function_exists( 'wc_get_template' ) ) {
-        wc_get_template( 'myaccount/form-edit-account.php', array( 'user' => $user ) );
-    } else {
-        do_action( 'woocommerce_account_edit-account_endpoint', 'edit-account' );
-    }
-
-    echo '</div>';
-}
 
 /**
  * Render the simple profile form for graduates.
@@ -674,12 +647,25 @@ function pspa_ms_simple_profile_form( $user_id ) {
             $requirement_text = esc_html__( 'έναν κωδικό πρόσβασης', 'pspa-membership-system' );
         }
 
+        $edit_account_url = function_exists( 'wc_get_account_endpoint_url' )
+            ? wc_get_account_endpoint_url( 'edit-account' )
+            : '';
+
         $message = sprintf(
-            esc_html__( 'Για να συνεχίσετε, προσθέστε %s χρησιμοποιώντας τη φόρμα «Στοιχεία λογαριασμού» που εμφανίζεται παραπάνω. Αφού αποθηκεύσετε τις αλλαγές, θα μπορείτε να ενημερώσετε το προφίλ σας.', 'pspa-membership-system' ),
+            esc_html__( 'Για να συνεχίσετε, προσθέστε %s από την ενότητα «Στοιχεία λογαριασμού» του λογαριασμού σας. Αφού αποθηκεύσετε τις αλλαγές, θα μπορείτε να ενημερώσετε το προφίλ σας.', 'pspa-membership-system' ),
             $requirement_text
         );
 
-        echo '<div class="pspa-dashboard pspa-profile-requirements"><p>' . $message . '</p></div>';
+        echo '<div class="pspa-dashboard pspa-profile-requirements">';
+        echo '<p>' . $message . '</p>';
+
+        if ( $edit_account_url ) {
+            echo '<p><a class="button" href="' . esc_url( $edit_account_url ) . '">';
+            esc_html_e( 'Μετάβαση στα στοιχεία λογαριασμού', 'pspa-membership-system' );
+            echo '</a></p>';
+        }
+
+        echo '</div>';
         return;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.92
+Stable tag: 0.0.93
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.93 =
+* Remove the embedded WooCommerce edit account form from the graduate profile endpoint and direct users to the native account editor instead.
 
 = 0.0.92 =
 * Ensure graduate profile save buttons use the WooCommerce "save_account_details" markup so account updates trigger verification.


### PR DESCRIPTION
## Summary
- remove the embedded WooCommerce edit account form from the graduate profile endpoint and rely on the native edit-account page
- update the graduate profile gating notice to link to the WooCommerce account details page and bump the plugin version metadata
- refresh the documentation to describe the updated credential management flow

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8ae2f99083279b7637059dc3b892