### PR TITLE
Hide admin IDs from Professional Catalogue front end

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.93
+ * Version: 0.0.94
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.93' );
+define( 'PSPA_MS_VERSION', '0.0.94' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -562,6 +562,47 @@ function pspa_ms_hide_public_visibility_toggles( $field ) {
 add_filter( 'acf/prepare_field', 'pspa_ms_hide_public_visibility_toggles', 20 );
 
 /**
+ * Get the list of graduate profile fields reserved for administrators.
+ *
+ * @return string[]
+ */
+function pspa_ms_get_admin_only_field_names() {
+    return array(
+        'gn_initial_db_id',
+        'gn_login_verified_date',
+        'gn_deceased',
+        'gn_show_deceased',
+    );
+}
+
+/**
+ * Fields hidden from Professional Catalogue users on the front end.
+ *
+ * @return string[]
+ */
+function pspa_ms_get_professional_catalogue_hidden_fields() {
+    return array(
+        'gn_initial_db_id',
+        'gn_login_verified_date',
+    );
+}
+
+/**
+ * Determine if the current user has the Professional Catalogue role.
+ *
+ * @return bool
+ */
+function pspa_ms_current_user_is_professional_catalogue() {
+    if ( ! is_user_logged_in() ) {
+        return false;
+    }
+
+    $current_user = wp_get_current_user();
+
+    return in_array( 'professionalcatalogue', (array) $current_user->roles, true );
+}
+
+/**
  * Hide admin-only fields from catalogue editors and graduate profile forms.
  *
  * @param array|false $field Field settings.
@@ -572,20 +613,13 @@ function pspa_ms_hide_admin_only_fields( $field ) {
         return $field;
     }
 
-    $admin_only = array(
-        'gn_initial_db_id',
-        'gn_login_verified_date',
-        'gn_deceased',
-        'gn_show_deceased',
-    );
+    $admin_only = pspa_ms_get_admin_only_field_names();
 
     if ( ! in_array( $field['name'], $admin_only, true ) ) {
         return $field;
     }
 
-    $current_user = wp_get_current_user();
-    $roles        = (array) $current_user->roles;
-    $is_catalogue = in_array( 'professionalcatalogue', $roles, true );
+    $is_catalogue = pspa_ms_current_user_is_professional_catalogue();
     $is_grad_form = function_exists( 'is_account_page' ) && is_account_page() && false !== get_query_var( 'graduate-profile', false );
 
     if ( $is_catalogue || $is_grad_form ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.93
+Stable tag: 0.0.94
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.94 =
+* Hide the Initial DB ID and login verification date fields from Professional Catalogue users on the front end.
+* Bump version to 0.0.94.
 
 = 0.0.93 =
 * Remove the embedded WooCommerce edit account form from the graduate profile endpoint and direct users to the native account editor instead.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -33,6 +33,10 @@ $visibility = function_exists( 'get_field' ) ? get_field( 'gn_visibility_mode', 
 $fields             = function_exists( 'acf_get_fields' ) ? acf_get_fields( 'group_gn_graduate_profile' ) : array();
 $header_field_names = array( 'gn_profile_picture', 'gn_first_name', 'gn_surname', 'gn_job_title', 'gn_position_company', 'gn_city', 'gn_country' );
 $header             = array( 'picture' => '', 'name' => array(), 'headline' => array(), 'location' => array() );
+$hide_catalogue_fields = function_exists( 'pspa_ms_current_user_is_professional_catalogue' ) && pspa_ms_current_user_is_professional_catalogue();
+$catalogue_hidden_fields = $hide_catalogue_fields && function_exists( 'pspa_ms_get_professional_catalogue_hidden_fields' )
+    ? pspa_ms_get_professional_catalogue_hidden_fields()
+    : array();
 
 foreach ( $header_field_names as $name ) {
     if ( 'hide_all' === $visibility ) {
@@ -44,6 +48,10 @@ foreach ( $header_field_names as $name ) {
             continue;
         }
     }
+    if ( $hide_catalogue_fields && in_array( $name, $catalogue_hidden_fields, true ) ) {
+        continue;
+    }
+
     $value = function_exists( 'get_field' ) ? get_field( $name, 'user_' . $uid ) : get_user_meta( $uid, $name, true );
 
     switch ( $name ) {
@@ -94,6 +102,10 @@ foreach ( $header_field_names as $name ) {
     <?php
     $current_section_open = false;
     foreach ( $fields as $field ) {
+        if ( ! is_array( $field ) ) {
+            continue;
+        }
+
         if ( 'tab' === $field['type'] ) {
             if ( isset( $field['key'] ) && 'tab_gn_visibility' === $field['key'] ) {
                 if ( $current_section_open ) {
@@ -107,6 +119,14 @@ foreach ( $header_field_names as $name ) {
             }
             echo '<section class="profile-section section-' . esc_attr( $field['name'] ) . '"><h2>' . esc_html( $field['label'] ) . '</h2><div class="profile-fields">';
             $current_section_open = true;
+            continue;
+        }
+
+        if ( empty( $field['name'] ) ) {
+            continue;
+        }
+
+        if ( $hide_catalogue_fields && in_array( $field['name'], $catalogue_hidden_fields, true ) ) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- add helpers to identify admin-only graduate profile fields and detect Professional Catalogue users
- hide the initial database ID and login verification date when catalogue editors view graduate profiles on the front end
- bump the plugin version to 0.0.94 and document the change in the readme

## Testing
- php -l pspa-membership-system.php
- php -l templates/graduate-public-profile.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8d0e5ff8832799191cb36a64cc48