### PR TITLE
Change graduate CTA label to Δείτε Περισσότερα and release 0.0.95

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Starting with version 0.0.45 names are matched case- and accent-insensitively by
 
 ## Graduate Directory
 
-The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking "Δείτε Περισσότερο" opens the graduate's public, non-editable profile. When logged in as an administrator or System Admin, cards also show an "Επεξεργασία" link to jump directly to the editing interface. Public profiles are also accessible directly at `/graduate/<username>/`.
+The `[pspa_graduate_directory]` shortcode outputs a grid of graduates showing their profile photo, full name and graduation year. Clicking "Δείτε Περισσότερα" opens the graduate's public, non-editable profile. When logged in as an administrator or System Admin, cards also show an "Επεξεργασία" link to jump directly to the editing interface. Public profiles are also accessible directly at `/graduate/<username>/`.
 
 ## Role-based Redirection
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.94
+ * Version: 0.0.95
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.94' );
+define( 'PSPA_MS_VERSION', '0.0.95' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -1576,7 +1576,7 @@ function pspa_ms_render_graduate_card( $user_id ) {
                 <p class="pspa-graduate-location"><?php echo esc_html( trim( $city . ( $country ? ', ' . $country : '' ) ) ); ?></p>
             <?php endif; ?>
             <div class="pspa-graduate-actions">
-                <a class="pspa-graduate-more" href="<?php echo esc_url( $profile_url ); ?>"><?php esc_html_e( 'Δείτε Περισσότερο', 'pspa-membership-system' ); ?></a>
+                <a class="pspa-graduate-more" href="<?php echo esc_url( $profile_url ); ?>"><?php esc_html_e( 'Δείτε Περισσότερα', 'pspa-membership-system' ); ?></a>
                 <?php if ( $can_edit ) : ?>
                     <a class="pspa-graduate-edit" href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Επεξεργασία', 'pspa-membership-system' ); ?></a>
                 <?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.94
+Stable tag: 0.0.95
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.95 =
+* Update graduate directory buttons to read "Δείτε Περισσότερα".
+* Bump version to 0.0.95.
 
 = 0.0.94 =
 * Hide the Initial DB ID and login verification date fields from Professional Catalogue users on the front end.
@@ -321,7 +325,7 @@ The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access
 = 0.0.10 =
 * Μεταφράστηκαν όλα τα κουμπιά και οι προεπιλεγμένες επιλογές στα ελληνικά.
 * Εφαρμόστηκε ενιαία εμφάνιση στα shortcodes και οι κάρτες αποφοίτων είναι πλέον κλικαμπλ.
-* Προστέθηκε κουμπί "Δείτε Περισσότερο" στις κάρτες αποφοίτων.
+* Προστέθηκε κουμπί "Δείτε Περισσότερα" στις κάρτες αποφοίτων.
 = 0.0.9 =
 * Fix fatal error during activation caused by duplicate shortcode definitions.
 = 0.0.8 =


### PR DESCRIPTION
## Summary
- update the graduate directory call-to-action to read "Δείτε Περισσότερα" in the template and documentation
- bump the plugin version metadata to 0.0.95 and record the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68ca910e7664832790f63cc09d661aae