### PR TITLE
Add directory visibility toggle for graduates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Dependencies:
 
 System Admins and site administrators can search for graduates and edit any user profile directly from the `Προφίλ Απόφοιτου` endpoint. The search covers all graduate fields and opens an editable form that mirrors the ACF data graduates see. Search results are displayed using the same card layout as the Graduate Directory, and cards include an edit button for administrators. Credential changes should be handled via the WooCommerce account form or the WordPress user editor.
 
+Administrators can also approve graduates for the public directory by toggling the **Εμφάνιση στον κατάλογο αποφοίτων** (`gn_directory_visible`) field. The switch defaults to off so graduates remain hidden until a System Admin reviews their profile.
+
 ## Login by Details
 
 The `[pspa_login_by_details]` shortcode renders a form asking for first name, last name and graduation year. When the details match a graduate record the user is logged in and redirected to the dashboard. The verification date is stored in the read-only `gn_login_verified_date` field only after the user sets an email and password via the profile form; once saved, subsequent login-by-details attempts are blocked.
@@ -113,3 +115,7 @@ The plugin registers a **Graduate Profile** field group in Advanced Custom Field
 - **Εμφάνιση στο δημόσιο προφίλ: Τίτλος** (`gn_show_job_title`, true_false)
 - **Θέση-Εταιρεία** (`gn_position_company`, text)
 - **Εμφάνιση στο δημόσιο προφίλ: Θέση-Εταιρεία** (`gn_show_position_company`, true_false)
+
+### Ρυθμίσεις ορατότητας
+- **Λειτουργία ορατότητας** (`gn_visibility_mode`, radio)
+- **Εμφάνιση στον κατάλογο αποφοίτων** (`gn_directory_visible`, true_false)

--- a/acf-export-2025-09-06-with-profile.json
+++ b/acf-export-2025-09-06-with-profile.json
@@ -1188,6 +1188,26 @@
         "save_other_choice": 0,
         "allow_null": 0,
         "return_format": "value"
+      },
+      {
+        "key": "field_gn_directory_visible",
+        "label": "Εμφάνιση στον κατάλογο αποφοίτων",
+        "name": "gn_directory_visible",
+        "aria-label": "",
+        "type": "true_false",
+        "instructions": "Ενεργοποιήστε για να εμφανίζεται ο απόφοιτος στον κατάλογο.",
+        "required": false,
+        "conditional_logic": false,
+        "wrapper": {
+          "width": "",
+          "class": "",
+          "id": ""
+        },
+        "default_value": 0,
+        "ui": 1,
+        "message": "",
+        "ui_on_text": "",
+        "ui_off_text": ""
       }
     ],
     "location": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.95
+Stable tag: 0.0.96
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.96 =
+* Add an administrator-only ACF toggle to control graduate directory visibility and default new users to hidden.
+* Hide public profiles for graduates marked as invisible unless viewed by an administrator.
+* Bump version to 0.0.96.
 
 = 0.0.95 =
 * Update graduate directory buttons to read "Δείτε Περισσότερα".

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -11,7 +11,17 @@
 
 $pspa_user = get_query_var( 'pspa_graduate_user' );
 
-if ( ! $pspa_user instanceof WP_User ) {
+$can_view_hidden = function_exists( 'pspa_ms_current_user_can_manage_directory_visibility' )
+    ? pspa_ms_current_user_can_manage_directory_visibility()
+    : current_user_can( 'manage_options' );
+
+if (
+    ! $pspa_user instanceof WP_User ||
+    ( ! $can_view_hidden && function_exists( 'pspa_ms_user_is_visible_in_directory' ) && ! pspa_ms_user_is_visible_in_directory( $pspa_user->ID ) )
+) {
+    if ( ! headers_sent() ) {
+        status_header( 404 );
+    }
     get_header();
     echo '<div class="pspa-dashboard"><p>' . esc_html__( 'Ο απόφοιτος δεν βρέθηκε.', 'pspa-membership-system' ) . '</p></div>';
     get_footer();


### PR DESCRIPTION
## Summary
- add an administrator-only `gn_directory_visible` ACF toggle so graduates stay hidden until approved
- gate graduate directory queries and public profile routes on the new visibility flag, while letting administrators view hidden records
- document the new workflow and bump the plugin version to 0.0.96

## Testing
- `php -l pspa-membership-system.php`
- `php -l templates/graduate-public-profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68ca95b822848327bd85cf8f72c3dcbb