### PR TITLE
Add graduate finder shortcode

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -1,0 +1,93 @@
+.pspa-graduate-finder {
+    max-width: 800px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.pspa-graduate-finder__filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.pspa-graduate-finder__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 600;
+}
+
+.pspa-graduate-finder__label {
+    font-size: 0.95rem;
+    color: #333;
+}
+
+.pspa-graduate-finder__field input {
+    padding: 0.6rem 0.75rem;
+    border: 1px solid #d6d6d6;
+    border-radius: 4px;
+    font: inherit;
+}
+
+.pspa-graduate-finder__field input:focus {
+    outline: 2px solid var(--ink, #3b2b22);
+    outline-offset: 1px;
+}
+
+.pspa-graduate-finder__results {
+    display: grid;
+    gap: 1rem;
+}
+
+.pspa-graduate-finder__results.is-loading {
+    opacity: 0.6;
+}
+
+.pspa-graduate-finder-card {
+    background: #fff;
+    border: 1px solid #e2e2e2;
+    border-radius: 6px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.pspa-graduate-finder-card__item {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.pspa-graduate-finder-card__label {
+    font-weight: 600;
+    color: #222;
+}
+
+.pspa-graduate-finder-card__value {
+    color: #444;
+}
+
+.pspa-finder-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.pspa-finder-pagination a {
+    padding: 0.45rem 0.85rem;
+    background: var(--ink, #3b2b22);
+    color: #fff;
+    border-radius: 4px;
+    text-decoration: none;
+}
+
+.pspa-finder-pagination .current {
+    font-weight: 600;
+}

--- a/assets/js/graduate-finder.js
+++ b/assets/js/graduate-finder.js
@@ -1,0 +1,69 @@
+jQuery(function($){
+    if (typeof pspaMsFinder === 'undefined') {
+        return;
+    }
+
+    $('.pspa-graduate-finder').each(function(){
+        var $container = $(this);
+        var $form = $container.find('.pspa-graduate-finder__filters');
+        var $results = $container.find('.pspa-graduate-finder__results');
+        var currentPage = 1;
+        var request = null;
+
+        function fetchResults(){
+            if (request && request.readyState !== 4) {
+                request.abort();
+            }
+
+            var data = {
+                action: 'pspa_ms_filter_graduate_finder',
+                nonce: pspaMsFinder.nonce,
+                page: currentPage,
+                first_name: $form.find('[name="first_name"]').val(),
+                last_name: $form.find('[name="last_name"]').val(),
+                graduation_year: $form.find('[name="graduation_year"]').val()
+            };
+
+            $results.addClass('is-loading');
+
+            request = $.post(pspaMsFinder.ajaxUrl, data)
+                .done(function(response){
+                    if (response && response.success && response.data && typeof response.data.html !== 'undefined') {
+                        $results.html(response.data.html);
+                    } else if (pspaMsFinder.errorMessage) {
+                        $results.html('<p>' + pspaMsFinder.errorMessage + '</p>');
+                    }
+                })
+                .fail(function(){
+                    if (pspaMsFinder.errorMessage) {
+                        $results.html('<p>' + pspaMsFinder.errorMessage + '</p>');
+                    }
+                })
+                .always(function(){
+                    $results.removeClass('is-loading');
+                    request = null;
+                });
+        }
+
+        $form.on('submit', function(event){
+            event.preventDefault();
+        });
+
+        $form.on('input', 'input', function(){
+            currentPage = 1;
+            fetchResults();
+        });
+
+        $results.on('click', '.pspa-finder-pagination a', function(event){
+            event.preventDefault();
+            var $link = $(this);
+            var page = parseInt($link.data('page'), 10);
+            if (!isNaN(page)) {
+                currentPage = page;
+                fetchResults();
+            }
+        });
+
+        fetchResults();
+    });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.97
+Stable tag: 0.0.98
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.98 =
+* Add a Graduate Finder shortcode with card-based results, search filters, and pagination for first name, last name, and graduation year.
+* Bump version to 0.0.98.
 
 = 0.0.97 =
 * Ensure graduate queries respect the directory visibility toggle for Professional Catalogue users.


### PR DESCRIPTION
## Summary
- add a Graduate Finder shortcode that renders searchable, paginated graduate cards showing first name, last name, and graduation year
- enqueue dedicated styles and JavaScript to support the finder layout and AJAX filtering
- bump the plugin version and document the new functionality in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68caa1fb15048327b205b996a75ed0c7