### PR TITLE
Align graduate finder cards with directory layout

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -45,30 +45,12 @@
     opacity: 0.6;
 }
 
-.pspa-graduate-finder-card {
-    background: #fff;
-    border: 1px solid #e2e2e2;
-    border-radius: 6px;
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.pspa-graduate-finder-card__item {
+.pspa-graduate-finder__results .pspa-graduate-card {
     margin: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
 }
 
-.pspa-graduate-finder-card__label {
-    font-weight: 600;
-    color: #222;
-}
-
-.pspa-graduate-finder-card__value {
-    color: #444;
+.pspa-graduate-card--finder {
+    width: 100%;
 }
 
 .pspa-finder-pagination {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.98
+Stable tag: 0.0.99
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.99 =
+* Update Graduate Finder results to use the graduate directory card layout, including profile photos.
+* Bump version to 0.0.99.
 
 = 0.0.98 =
 * Add a Graduate Finder shortcode with card-based results, search filters, and pagination for first name, last name, and graduation year.


### PR DESCRIPTION
## Summary
- restyle the graduate finder results to reuse the graduate directory card markup so avatars and actions match the directory design
- allow extra CSS classes when rendering graduate cards, load the directory stylesheet for the finder, and tune finder styles for the shared layout
- bump the plugin to version 0.0.99 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68caa57ad9a08327a210d7d927500c01