### PR TITLE
Update last name label text and bump version to 0.0.100

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.99
+ * Version: 0.0.100
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.99' );
+define( 'PSPA_MS_VERSION', '0.0.100' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -1257,7 +1257,7 @@ function pspa_ms_login_by_details_shortcode() {
             <input type="text" name="first_name" id="first_name" required />
         </p>
         <p class="form-row form-row-wide">
-            <label for="last_name"><?php esc_html_e( 'Επίθετο', 'pspa-membership-system' ); ?></label>
+            <label for="last_name"><?php esc_html_e( 'Επώνυμο', 'pspa-membership-system' ); ?></label>
             <input type="text" name="last_name" id="last_name" required />
         </p>
         <p class="form-row form-row-wide">
@@ -1748,8 +1748,8 @@ function pspa_ms_graduate_finder_shortcode() {
                 <input type="text" id="<?php echo esc_attr( $form_id ); ?>-first" name="first_name" placeholder="<?php esc_attr_e( 'Όνομα', 'pspa-membership-system' ); ?>" autocomplete="off" />
             </label>
             <label class="pspa-graduate-finder__field" for="<?php echo esc_attr( $form_id ); ?>-last">
-                <span class="pspa-graduate-finder__label"><?php esc_html_e( 'Επίθετο', 'pspa-membership-system' ); ?></span>
-                <input type="text" id="<?php echo esc_attr( $form_id ); ?>-last" name="last_name" placeholder="<?php esc_attr_e( 'Επίθετο', 'pspa-membership-system' ); ?>" autocomplete="off" />
+                <span class="pspa-graduate-finder__label"><?php esc_html_e( 'Επώνυμο', 'pspa-membership-system' ); ?></span>
+                <input type="text" id="<?php echo esc_attr( $form_id ); ?>-last" name="last_name" placeholder="<?php esc_attr_e( 'Επώνυμο', 'pspa-membership-system' ); ?>" autocomplete="off" />
             </label>
             <label class="pspa-graduate-finder__field" for="<?php echo esc_attr( $form_id ); ?>-year">
                 <span class="pspa-graduate-finder__label"><?php esc_html_e( 'Έτος Αποφοίτησης', 'pspa-membership-system' ); ?></span>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.99
+Stable tag: 0.0.100
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.100 =
+* Update last name labels to use "Επώνυμο" for improved clarity.
+* Bump version to 0.0.100.
 
 = 0.0.99 =
 * Update Graduate Finder results to use the graduate directory card layout, including profile photos.


### PR DESCRIPTION
## Summary
- update the last name labels and placeholders to use the word "Επώνυμο"
- bump the plugin version to 0.0.100 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68caa778088883278c1ae59e5863585e