### PR TITLE
Restrict Graduate Finder queries to Professional Catalogue role

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.100
+ * Version: 0.0.101
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.100' );
+define( 'PSPA_MS_VERSION', '0.0.101' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -1990,6 +1990,7 @@ function pspa_ms_ajax_filter_graduate_finder() {
         'count_total' => true,
         'orderby'     => 'display_name',
         'order'       => 'ASC',
+        'role__in'    => array( 'professionalcatalogue' ),
     );
 
     $users_query = new WP_User_Query( $query_args );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.100
+Stable tag: 0.0.101
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.101 =
+* Restrict Graduate Finder searches to the Professional Catalogue role.
+* Bump version to 0.0.101.
 
 = 0.0.100 =
 * Update last name labels to use "Επώνυμο" for improved clarity.


### PR DESCRIPTION
## Summary
- restrict graduate finder AJAX queries to professionalcatalogue users
- bump plugin version to 0.0.101 and update changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68caa89ef1848327bc4d7219a412af93