### PR TITLE
Respect graduate profile visibility toggles on public profiles

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.101
+ * Version: 0.0.102
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.101' );
+define( 'PSPA_MS_VERSION', '0.0.102' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.101
+Stable tag: 0.0.102
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.102 =
+* Respect graduate public profile visibility toggles so hidden fields stay hidden.
+* Bump version to 0.0.102.
 
 = 0.0.101 =
 * Restrict Graduate Finder searches to the Professional Catalogue role.


### PR DESCRIPTION
## Summary
- ensure the graduate public profile reuses a helper to honour field-level visibility toggles
- reuse the computed user meta key while fetching field data
- bump the plugin version to 0.0.102 and document the change in the readme

## Testing
- php -l pspa-membership-system.php
- php -l templates/graduate-public-profile.php

------
https://chatgpt.com/codex/tasks/task_e_68caac68637083278c3fc8b512971d7a