### PR TITLE
Hide admin fields on public profiles

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.102
+ * Version: 0.0.103
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.102' );
+define( 'PSPA_MS_VERSION', '0.0.103' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -588,6 +588,7 @@ function pspa_ms_get_professional_catalogue_hidden_fields() {
     return array(
         'gn_initial_db_id',
         'gn_login_verified_date',
+        'gn_directory_visible',
     );
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.102
+Stable tag: 0.0.103
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.103 =
+* Hide admin-only graduate fields from public profiles unless the viewer can manage directory visibility.
+* Extend Professional Catalogue field restrictions to cover the directory visibility toggle.
+* Bump version to 0.0.103.
 
 = 0.0.102 =
 * Respect graduate public profile visibility toggles so hidden fields stay hidden.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -48,6 +48,12 @@ $hide_catalogue_fields = function_exists( 'pspa_ms_current_user_is_professional_
 $catalogue_hidden_fields = $hide_catalogue_fields && function_exists( 'pspa_ms_get_professional_catalogue_hidden_fields' )
     ? pspa_ms_get_professional_catalogue_hidden_fields()
     : array();
+$admin_hidden_fields = array();
+if ( ! $can_view_hidden ) {
+    $admin_hidden_fields = function_exists( 'pspa_ms_get_admin_only_field_names' )
+        ? pspa_ms_get_admin_only_field_names()
+        : array( 'gn_initial_db_id', 'gn_login_verified_date', 'gn_directory_visible', 'gn_deceased', 'gn_show_deceased' );
+}
 
 $should_show_field = static function ( $field_name ) use ( $uid, $user_key, $visibility ) {
     if ( 'hide_all' === $visibility ) {
@@ -72,6 +78,10 @@ $should_show_field = static function ( $field_name ) use ( $uid, $user_key, $vis
 
 foreach ( $header_field_names as $name ) {
     if ( ! $should_show_field( $name ) ) {
+        continue;
+    }
+
+    if ( $admin_hidden_fields && in_array( $name, $admin_hidden_fields, true ) ) {
         continue;
     }
     if ( $hide_catalogue_fields && in_array( $name, $catalogue_hidden_fields, true ) ) {
@@ -149,6 +159,10 @@ foreach ( $header_field_names as $name ) {
         }
 
         if ( empty( $field['name'] ) ) {
+            continue;
+        }
+
+        if ( $admin_hidden_fields && in_array( $field['name'], $admin_hidden_fields, true ) ) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- prevent admin-only graduate fields from rendering on public profiles unless the viewer can manage directory visibility
- extend the Professional Catalogue hidden-field list to cover the directory visibility toggle
- bump the plugin version to 0.0.103 and document the change in the readme

## Testing
- php -l pspa-membership-system.php
- php -l templates/graduate-public-profile.php

------
https://chatgpt.com/codex/tasks/task_e_68cab06a31f083278b72404332f74e79