### PR TITLE
Add graduate profile intro instructions

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.103
+ * Version: 0.0.104
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.103' );
+define( 'PSPA_MS_VERSION', '0.0.104' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -755,6 +755,14 @@ function pspa_ms_simple_profile_form( $user_id ) {
     }
 
     ?>
+    <div class="pspa-dashboard pspa-graduate-profile-intro">
+        <p>
+            <?php esc_html_e( 'Επεξεργαστείτε τα στοιχεία σας, που θα φαίνονται στην αναζήτηση αποφοίτων (ονοματεπώνυμο, έτος αποφοίτησης, τηλέφωνο επικοινωνίας) και επιλέξτε αν θέλετε να εμφανίζεστε στον Επαγγελματικό Κατάλογο των αποφοίτων του ΠΣΠΑ και ποια στοιχεία σας θα είναι ορατά.', 'pspa-membership-system' ); ?>
+        </p>
+        <p>
+            <?php esc_html_e( '(Απαραίτητη προϋπόθεση για τη συμμετοχή σας στο Επαγγελματικό Κατάλογο αποτελεί να είστε ταμειακώς εντάξει).', 'pspa-membership-system' ); ?>
+        </p>
+    </div>
     <form class="woocommerce-EditAccountForm edit-account pspa-dashboard" method="post">
         <?php if ( function_exists( 'acf_form' ) ) : ?>
             <?php acf_form( array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.103
+Stable tag: 0.0.104
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.104 =
+* Add introductory guidance to the graduate profile form about Professional Catalogue visibility requirements.
+* Bump version to 0.0.104.
 
 = 0.0.103 =
 * Hide admin-only graduate fields from public profiles unless the viewer can manage directory visibility.


### PR DESCRIPTION
## Summary
- add an introductory notice on the graduate profile dashboard to explain how catalogue visibility works
- bump the plugin version to 0.0.104 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cab52fb6e88327a12ee29ebf3af022