### PR TITLE
Style graduate profile eligibility note

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -18,3 +18,4 @@
 .pspa-dashboard .password-strength.short,.pspa-dashboard .password-strength.bad{background:#ffb78c;border-color:#ff853c}
 .pspa-dashboard .password-strength.good{background:#ffec8b;border-color:#e6db55}
 .pspa-dashboard .password-strength.strong{background:#c1e1b9;border-color:#83c373}
+.pspa-dashboard .pspa-graduate-profile-note{margin-bottom:30px}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.104
+ * Version: 0.0.105
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.104' );
+define( 'PSPA_MS_VERSION', '0.0.105' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -759,8 +759,8 @@ function pspa_ms_simple_profile_form( $user_id ) {
         <p>
             <?php esc_html_e( 'Επεξεργαστείτε τα στοιχεία σας, που θα φαίνονται στην αναζήτηση αποφοίτων (ονοματεπώνυμο, έτος αποφοίτησης, τηλέφωνο επικοινωνίας) και επιλέξτε αν θέλετε να εμφανίζεστε στον Επαγγελματικό Κατάλογο των αποφοίτων του ΠΣΠΑ και ποια στοιχεία σας θα είναι ορατά.', 'pspa-membership-system' ); ?>
         </p>
-        <p>
-            <?php esc_html_e( '(Απαραίτητη προϋπόθεση για τη συμμετοχή σας στο Επαγγελματικό Κατάλογο αποτελεί να είστε ταμειακώς εντάξει).', 'pspa-membership-system' ); ?>
+        <p class="pspa-graduate-profile-note">
+            <em><?php esc_html_e( '(Απαραίτητη προϋπόθεση για τη συμμετοχή σας στο Επαγγελματικό Κατάλογο αποτελεί να είστε ταμειακώς εντάξει).', 'pspa-membership-system' ); ?></em>
         </p>
     </div>
     <form class="woocommerce-EditAccountForm edit-account pspa-dashboard" method="post">

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.104
+Stable tag: 0.0.105
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.105 =
+* Style the Professional Catalogue eligibility note with italics and additional spacing.
+* Bump version to 0.0.105.
 
 = 0.0.104 =
 * Add introductory guidance to the graduate profile form about Professional Catalogue visibility requirements.


### PR DESCRIPTION
## Summary
- italicize the Professional Catalogue eligibility reminder on the graduate profile form and give it bottom spacing
- add dashboard stylesheet support for the new note spacing
- bump the PSPA Membership System plugin version to 0.0.105

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cab7a7f6dc8327a3ebf0eae230d1a4