### PR TITLE
Hide deceased fields from Professional Catalogue users

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.105
+ * Version: 0.0.106
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.105' );
+define( 'PSPA_MS_VERSION', '0.0.106' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -623,6 +623,30 @@ function pspa_ms_current_user_is_professional_catalogue() {
 
     return in_array( 'professionalcatalogue', (array) $current_user->roles, true );
 }
+
+/**
+ * Hide deceased status controls from Professional Catalogue users on graduate profile forms.
+ *
+ * @param array $field Field settings.
+ * @return array|false
+ */
+function pspa_ms_hide_deceased_fields_for_professional_catalogue( $field ) {
+    if ( ! is_array( $field ) ) {
+        return $field;
+    }
+
+    if ( ! pspa_ms_current_user_is_professional_catalogue() ) {
+        return $field;
+    }
+
+    if ( ! pspa_ms_is_graduate_profile_endpoint() ) {
+        return $field;
+    }
+
+    return false;
+}
+add_filter( 'acf/prepare_field/name=gn_deceased', 'pspa_ms_hide_deceased_fields_for_professional_catalogue', 25 );
+add_filter( 'acf/prepare_field/name=gn_show_deceased', 'pspa_ms_hide_deceased_fields_for_professional_catalogue', 25 );
 
 /**
  * Determine if the current user can manage graduate directory visibility.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.105
+Stable tag: 0.0.106
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.106 =
+* Hide the deceased status fields from Professional Catalogue users on the graduate profile endpoint.
+* Bump version to 0.0.106.
 
 = 0.0.105 =
 * Hide the Initial DB ID and login verification date fields for Professional Catalogue users on the graduate profile endpoint.


### PR DESCRIPTION
## Summary
- prevent Professional Catalogue users from seeing the deceased status controls on the graduate profile endpoint
- bump the plugin version to 0.0.106 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cabc34f8608327a5e83e77eecb70fa