### PR TITLE
Uniform address field widths and version bump

### DIFF
--- a/acf-export-2025-09-06-with-profile.json
+++ b/acf-export-2025-09-06-with-profile.json
@@ -679,7 +679,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "60",
+          "width": "50",
           "class": "",
           "id": ""
         },
@@ -699,7 +699,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "60",
+          "width": "50",
           "class": "",
           "id": ""
         },
@@ -719,7 +719,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "20",
+          "width": "50",
           "class": "",
           "id": ""
         },
@@ -739,7 +739,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "20",
+          "width": "50",
           "class": "",
           "id": ""
         },
@@ -759,7 +759,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "20",
+          "width": "50",
           "class": "",
           "id": ""
         },
@@ -779,7 +779,7 @@
         "required": false,
         "conditional_logic": false,
         "wrapper": {
-          "width": "20",
+          "width": "50",
           "class": "",
           "id": ""
         },

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.106
+ * Version: 0.0.107
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.106' );
+define( 'PSPA_MS_VERSION', '0.0.107' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.106
+Stable tag: 0.0.107
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.107 =
+* Set all address tab fields to a uniform 50% width for consistent alignment.
+* Bump version to 0.0.107.
 
 = 0.0.106 =
 * Hide the deceased status fields from Professional Catalogue users on the graduate profile endpoint.


### PR DESCRIPTION
## Summary
- set the ACF address tab field wrappers to 50% widths for consistent presentation
- bump the plugin version and changelog to 0.0.107

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cac76b37688327b453457e206c6f0f