### PR TITLE
Let dashboard buttons inherit WooCommerce styling

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -11,7 +11,6 @@
 .pspa-user-search-results{margin:0;padding:0}
 .pspa-dashboard .form-row{margin-bottom:12px}
 .pspa-dashboard label{display:block;margin-bottom:4px;color:var(--ink);font-weight:600}
-.pspa-dashboard .woocommerce-Button.button{background:var(--ink);color:#fff;border-radius:10px;padding:10px 15px}
 .pspa-dashboard .password-input{position:relative;display:block}
 .pspa-dashboard .password-input .show-password-input{color:var(--ink)}
 .pspa-dashboard .password-strength{margin-top:4px;padding:5px;border:1px solid var(--line);border-radius:10px;text-align:center;background:#eee;color:var(--ink)}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.107
+ * Version: 0.0.108
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.107' );
+define( 'PSPA_MS_VERSION', '0.0.108' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -786,7 +786,7 @@ function pspa_ms_simple_profile_form( $user_id ) {
         echo '<p>' . $message . '</p>';
 
         if ( $edit_account_url ) {
-            echo '<p><a class="button" href="' . esc_url( $edit_account_url ) . '">';
+            echo '<p><a class="woocommerce-Button button" href="' . esc_url( $edit_account_url ) . '">';
             esc_html_e( 'Μετάβαση στα στοιχεία λογαριασμού', 'pspa-membership-system' );
             echo '</a></p>';
         }
@@ -918,7 +918,7 @@ function pspa_ms_admin_profile_interface() {
 
     $add_url = add_query_arg( 'add_user', 1, pspa_ms_get_graduate_profile_edit_url() );
     echo '<div class="pspa-dashboard pspa-admin-dashboard">';
-    echo '<p><a class="button" href="' . esc_url( $add_url ) . '">' . esc_html__( 'Προσθήκη χρήστη', 'pspa-membership-system' ) . '</a></p>';
+    echo '<p><a class="woocommerce-Button button" href="' . esc_url( $add_url ) . '">' . esc_html__( 'Προσθήκη χρήστη', 'pspa-membership-system' ) . '</a></p>';
     echo '</div>';
 
     echo pspa_ms_graduate_directory_shortcode();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.107
+Stable tag: 0.0.108
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.108 =
+* Remove custom dashboard button styling so WooCommerce/Divi defaults apply.
+* Bump version to 0.0.108.
 
 = 0.0.107 =
 * Set all address tab fields to a uniform 50% width for consistent alignment.


### PR DESCRIPTION
## Summary
- remove the dashboard button override so WooCommerce/Divi styling applies automatically
- ensure dashboard call-to-action links use the WooCommerce button classes for consistent styling
- bump the plugin version to 0.0.108 and update the readme changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cacf0263d88327ba49d9e6e983316d