### PR TITLE
Style graduate profile tabs

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -18,3 +18,10 @@
 .pspa-dashboard .password-strength.good{background:#ffec8b;border-color:#e6db55}
 .pspa-dashboard .password-strength.strong{background:#c1e1b9;border-color:#83c373}
 .pspa-dashboard .pspa-graduate-profile-note{margin-bottom:30px}
+.pspa-dashboard .acf-tab-group{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 24px;padding:0;list-style:none}
+.pspa-dashboard .acf-tab-group>li{margin:0}
+.pspa-dashboard .acf-tab-group .acf-tab-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;border-radius:999px;border:1px solid var(--line);background:var(--card);color:var(--ink);font-weight:600;text-decoration:none;transition:background-color .2s ease,border-color .2s ease,color .2s ease}
+.pspa-dashboard .acf-tab-group .acf-tab-button:hover,.pspa-dashboard .acf-tab-group .acf-tab-button:focus{background:#fff;border-color:var(--ink);color:var(--ink)}
+.pspa-dashboard .acf-tab-group>li.active .acf-tab-button{background:var(--ink);border-color:var(--ink);color:#fff}
+.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:hover,.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:focus{color:#fff}
+.pspa-dashboard .acf-tab-group .acf-tab-button:focus-visible{outline:2px solid var(--ink);outline-offset:2px}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.109
+ * Version: 0.0.110
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.109' );
+define( 'PSPA_MS_VERSION', '0.0.110' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.109
+Stable tag: 0.0.110
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.110 =
+* Style graduate profile tabs to match other dashboard tabs.
+* Bump version to 0.0.110.
 
 = 0.0.109 =
 * Allow graduate directory and WooCommerce actions to inherit Divi button styling.


### PR DESCRIPTION
## Summary
- style graduate profile ACF tabs so they share the same look and feel as the other dashboard tabs
- ensure hover, focus, and active states preserve the colour scheme and accessibility
- bump the plugin version to 0.0.110 and document the change in the readme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad470c95883278952facd739aac10