### PR TITLE
Restrict front-end profile picture selection to uploads

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.110
+ * Version: 0.0.111
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.110' );
+define( 'PSPA_MS_VERSION', '0.0.111' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -563,6 +563,28 @@ function pspa_ms_hide_public_visibility_toggles( $field ) {
     return $field;
 }
 add_filter( 'acf/prepare_field', 'pspa_ms_hide_public_visibility_toggles', 20 );
+
+/**
+ * Force the profile picture field to use the basic uploader on the front end.
+ *
+ * Front-end users should upload a new image instead of browsing the existing
+ * media library. Switching to the basic uploader removes the media library
+ * interface and presents a simple file picker that defaults to uploads.
+ *
+ * @param array $field Field settings.
+ * @return array
+ */
+function pspa_ms_lock_profile_picture_to_uploads( $field ) {
+    if ( is_admin() ) {
+        return $field;
+    }
+
+    $field['uploader'] = 'basic';
+    $field['library']  = 'uploadedTo';
+
+    return $field;
+}
+add_filter( 'acf/prepare_field/name=gn_profile_picture', 'pspa_ms_lock_profile_picture_to_uploads' );
 
 /**
  * Get the list of graduate profile fields reserved for administrators.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.110
+Stable tag: 0.0.111
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.111 =
+* Require new profile photo uploads on front-end forms by switching the image field to the basic uploader.
+* Bump version to 0.0.111.
 
 = 0.0.110 =
 * Style graduate profile tabs to match other dashboard tabs.


### PR DESCRIPTION
## Summary
- switch the front-end profile photo field to ACF's basic uploader so users upload new files instead of browsing the media library
- bump the plugin version to 0.0.111 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cad5f692e88327add88e9be72c35c4