### PR TITLE
Align graduate profile tabs with Woo account menu

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -18,10 +18,12 @@
 .pspa-dashboard .password-strength.good{background:#ffec8b;border-color:#e6db55}
 .pspa-dashboard .password-strength.strong{background:#c1e1b9;border-color:#83c373}
 .pspa-dashboard .pspa-graduate-profile-note{margin-bottom:30px}
-.pspa-dashboard .acf-tab-group{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 24px;padding:0;list-style:none}
-.pspa-dashboard .acf-tab-group>li{margin:0}
-.pspa-dashboard .acf-tab-group .acf-tab-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;border-radius:999px;border:1px solid var(--line);background:var(--card);color:var(--ink);font-weight:600;text-decoration:none;transition:background-color .2s ease,border-color .2s ease,color .2s ease}
-.pspa-dashboard .acf-tab-group .acf-tab-button:hover,.pspa-dashboard .acf-tab-group .acf-tab-button:focus{background:#fff;border-color:var(--ink);color:var(--ink)}
-.pspa-dashboard .acf-tab-group>li.active .acf-tab-button{background:var(--ink);border-color:var(--ink);color:#fff}
-.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:hover,.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:focus{color:#fff}
+.pspa-dashboard .acf-tab-group{list-style:none;margin:0 0 20px;padding:0}
+.pspa-dashboard .acf-tab-group>li{margin:0 0 8px;background:var(--card);border:1px solid var(--line);border-radius:10px;transition:border-color .2s ease,background-color .2s ease}
+.pspa-dashboard .acf-tab-group>li:last-child{margin-bottom:0}
+.pspa-dashboard .acf-tab-group .acf-tab-button{display:block;padding:8px 12px;color:var(--ink);text-decoration:none;border-radius:10px;transition:color .2s ease,background-color .2s ease}
+.pspa-dashboard .acf-tab-group .acf-tab-button:hover,.pspa-dashboard .acf-tab-group .acf-tab-button:focus{background:#fff;color:var(--ink)}
+.pspa-dashboard .acf-tab-group>li.active{background:var(--ink);border-color:var(--ink)}
+.pspa-dashboard .acf-tab-group>li.active .acf-tab-button{background:transparent;color:#fff;font-weight:600}
+.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:hover,.pspa-dashboard .acf-tab-group>li.active .acf-tab-button:focus{background:transparent;color:#fff}
 .pspa-dashboard .acf-tab-group .acf-tab-button:focus-visible{outline:2px solid var(--ink);outline-offset:2px}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.111
+ * Version: 0.0.113
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.111' );
+define( 'PSPA_MS_VERSION', '0.0.113' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.111
+Stable tag: 0.0.113
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,14 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.113 =
+* Restore the graduate profile tab color treatment while keeping the WooCommerce navigation layout.
+* Bump version to 0.0.113.
+
+= 0.0.112 =
+* Match the graduate profile tab styling to the WooCommerce account navigation.
+* Bump version to 0.0.112.
 
 = 0.0.111 =
 * Require new profile photo uploads on front-end forms by switching the image field to the basic uploader.


### PR DESCRIPTION
## Summary
- restyle the graduate profile ACF tab list to reuse the WooCommerce account navigation look and feel
- restore the graduate profile tab color treatment so the active state matches existing styling cues
- bump the plugin version to 0.0.113 and document the change in the readme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cad74eb194832789619879e2d5cd27