### PR TITLE
Adjust ACF tab styling

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -31,3 +31,5 @@
 .pspa-dashboard .acf-tab-group .acf-tab-button{display:block;padding:8px 12px;color:var(--ink);text-decoration:none}
 .pspa-dashboard .acf-tab-group>li.active .acf-tab-button{font-weight:600}
 .pspa-dashboard .acf-tab-group .acf-tab-button:focus-visible{outline:2px solid var(--ink);outline-offset:2px}
+.acf-tab-wrap.-left .acf-tab-group li a{border:1px solid #fffaf5;font-size:13px;line-height:18px;color:#0073aa;padding:10px;margin:0;font-weight:400;border-width:1px 0;border-radius:0;background:#fffaf5!important}
+.acf-fields>.acf-tab-wrap .acf-tab-group li a{background:#f1f1f1;border:1px solid #e4d6c8!important;color:var(--ink,#3b2b22)!important}

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.113
+ * Version: 0.0.114
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.113' );
+define( 'PSPA_MS_VERSION', '0.0.114' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.113
+Stable tag: 0.0.114
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.114 =
+* Update ACF tab styling to use the light card palette on left-aligned layouts.
+* Bump version to 0.0.114.
 
 = 0.0.113 =
 * Restore the graduate profile tab color treatment while keeping the WooCommerce navigation layout.


### PR DESCRIPTION
## Summary
- restyle ACF dashboard tabs to match the light card palette and update left-aligned tab appearance
- bump the plugin version to 0.0.114 and document the change in the readme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cae1a62cc4832784d2baa200e719b1