### PR TITLE
Grant graduates permission to upload profile photos

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.116
+ * Version: 0.0.117
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.116' );
+define( 'PSPA_MS_VERSION', '0.0.117' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -184,6 +184,36 @@ function pspa_ms_enqueue_password_strength() {
     );
 }
 add_action( 'wp_enqueue_scripts', 'pspa_ms_enqueue_password_strength' );
+
+/**
+ * Allow graduate-facing roles to upload profile photos.
+ *
+ * Front-end ACF forms still require the `upload_files` capability when
+ * handling uploads via the basic uploader. Graduates were blocked from adding
+ * profile photos because the Customer-derived roles they use do not grant this
+ * capability by default. Grant it here so the upload endpoint authorises the
+ * request without restoring wp-admin access.
+ */
+function pspa_ms_allow_graduate_uploads() {
+    if ( ! function_exists( 'get_role' ) ) {
+        return;
+    }
+
+    $roles = array( 'customer', 'professionalcatalogue', 'system-admin', 'sysadmin' );
+
+    foreach ( $roles as $role_key ) {
+        $role = get_role( $role_key );
+
+        if ( ! $role ) {
+            continue;
+        }
+
+        if ( ! $role->has_cap( 'upload_files' ) ) {
+            $role->add_cap( 'upload_files' );
+        }
+    }
+}
+add_action( 'init', 'pspa_ms_allow_graduate_uploads' );
 
 /**
  * Retrieve the URL shown after a login-by-details failure.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.116
+Stable tag: 0.0.117
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.117 =
+* Grant graduate-facing roles the `upload_files` capability so profile photo uploads succeed.
+* Bump version to 0.0.117.
 
 = 0.0.116 =
 * Redirect front page membership purchase links directly to the checkout so the cart remains populated.


### PR DESCRIPTION
## Summary
- grant the `upload_files` capability to graduate-facing roles so profile photo uploads succeed
- bump the plugin version to 0.0.117 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7ff1f45c8327961a0dfbc02dc362