### PR TITLE
Allow async uploads for graduate profile photos

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.117
+Stable tag: 0.0.118
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.118 =
+* Allow graduate-facing roles to complete asynchronous media uploads so profile photo updates succeed.
+* Bump version to 0.0.118.
 
 = 0.0.117 =
 * Grant graduate-facing roles the `upload_files` capability so profile photo uploads succeed.


### PR DESCRIPTION
## Summary
- skip the admin redirect for the async-upload.php handler so graduate-facing roles can complete media uploads
- bump the plugin version to 0.0.118 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cd81dc40f08327ad0462e3b033a4f2