### PR TITLE
Add custom profile picture uploader

### DIFF
--- a/assets/css/profile-picture-uploader.css
+++ b/assets/css/profile-picture-uploader.css
@@ -1,0 +1,90 @@
+.pspa-profile-picture-field--customized .acf-image-uploader,
+.pspa-profile-picture-field--customized .acf-basic-uploader {
+    display: none !important;
+}
+
+.pspa-profile-picture-uploader {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1.25rem;
+    border: 1px solid #dcdfe5;
+    border-radius: 12px;
+    background-color: #fff;
+}
+
+.pspa-profile-picture-preview {
+    position: relative;
+    width: 128px;
+    height: 128px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: #f1f3f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.pspa-profile-picture-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.pspa-profile-picture-placeholder {
+    display: block;
+    text-align: center;
+    font-size: 0.875rem;
+    color: #6c757d;
+    padding: 0 0.5rem;
+}
+
+.pspa-profile-picture-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 200px;
+}
+
+.pspa-profile-picture-controls .button {
+    align-self: flex-start;
+}
+
+.pspa-profile-picture-remove {
+    margin-left: 0;
+}
+
+.pspa-profile-picture-status {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #2271b1;
+}
+
+.pspa-profile-picture-status.is-error {
+    color: #b32d2e;
+}
+
+.pspa-profile-picture-uploader.is-uploading {
+    opacity: 0.7;
+}
+
+@media (max-width: 600px) {
+    .pspa-profile-picture-uploader {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .pspa-profile-picture-preview {
+        margin: 0 auto;
+    }
+
+    .pspa-profile-picture-controls {
+        width: 100%;
+    }
+
+    .pspa-profile-picture-controls .button {
+        width: 100%;
+        text-align: center;
+    }
+}

--- a/assets/js/profile-picture-uploader.js
+++ b/assets/js/profile-picture-uploader.js
@@ -1,0 +1,297 @@
+(function () {
+    const settings = window.pspaMSProfilePicture;
+
+    if (!settings || !settings.fieldKey) {
+        return;
+    }
+
+    const allowedExtensions = Array.isArray(settings.allowedExtensions)
+        ? settings.allowedExtensions.map((extension) => String(extension).toLowerCase())
+        : [];
+
+    const ready = (callback) => {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback);
+        } else {
+            callback();
+        }
+    };
+
+    ready(() => {
+        const field = document.querySelector(
+            '.acf-field[data-key="' + settings.fieldKey + '"]'
+        );
+
+        if (!field) {
+            return;
+        }
+
+        field.classList.add('pspa-profile-picture-field--customized');
+
+        field
+            .querySelectorAll('.acf-image-uploader, .acf-basic-uploader')
+            .forEach((uploader) => {
+                uploader.style.display = 'none';
+            });
+
+        const acfValueInput = field.querySelector('input[type="hidden"][name^="acf"]');
+        const acfIdInput = field.querySelector('input[type="hidden"][data-name="id"]');
+        const acfUrlInput = field.querySelector('input[type="hidden"][data-name="url"]');
+        const acfAltInput = field.querySelector('input[type="hidden"][data-name="alt"]');
+
+        const container = document.createElement('div');
+        container.className = 'pspa-profile-picture-uploader';
+
+        const previewWrapper = document.createElement('div');
+        previewWrapper.className = 'pspa-profile-picture-preview';
+
+        const previewImage = document.createElement('img');
+        previewImage.className = 'pspa-profile-picture-image';
+        previewImage.alt = '';
+        previewImage.setAttribute('hidden', 'hidden');
+
+        const placeholder = document.createElement('span');
+        placeholder.className = 'pspa-profile-picture-placeholder';
+        placeholder.textContent =
+            (settings.strings && settings.strings.placeholder) || '';
+
+        previewWrapper.appendChild(previewImage);
+        previewWrapper.appendChild(placeholder);
+
+        const controls = document.createElement('div');
+        controls.className = 'pspa-profile-picture-controls';
+
+        const uploadButton = document.createElement('button');
+        uploadButton.type = 'button';
+        uploadButton.className = 'button pspa-profile-picture-upload';
+        uploadButton.textContent =
+            (settings.strings && settings.strings.upload) || 'Upload';
+
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'button pspa-profile-picture-remove';
+        removeButton.textContent =
+            (settings.strings && settings.strings.remove) || 'Remove';
+
+        const status = document.createElement('p');
+        status.className = 'pspa-profile-picture-status';
+        status.setAttribute('role', 'status');
+        status.setAttribute('aria-live', 'polite');
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = 'image/*';
+        fileInput.className = 'pspa-profile-picture-file';
+        fileInput.style.display = 'none';
+
+        controls.appendChild(uploadButton);
+        controls.appendChild(removeButton);
+        controls.appendChild(status);
+        controls.appendChild(fileInput);
+
+        container.appendChild(previewWrapper);
+        container.appendChild(controls);
+
+        const customHiddenInput = document.createElement('input');
+        customHiddenInput.type = 'hidden';
+        customHiddenInput.name = 'pspa_profile_picture_attachment';
+        container.appendChild(customHiddenInput);
+
+        const inputWrapper = field.querySelector('.acf-input') || field;
+        const instructions = inputWrapper.querySelector(
+            '.acf-field-instructions, .description'
+        );
+
+        if (instructions) {
+            instructions.parentNode.insertBefore(container, instructions);
+        } else {
+            inputWrapper.appendChild(container);
+        }
+
+        const setPreview = (url) => {
+            if (url) {
+                previewImage.src = url;
+                previewImage.removeAttribute('hidden');
+                placeholder.setAttribute('hidden', 'hidden');
+            } else {
+                previewImage.removeAttribute('src');
+                previewImage.setAttribute('hidden', 'hidden');
+                placeholder.removeAttribute('hidden');
+            }
+        };
+
+        const setStatus = (message, isError) => {
+            status.textContent = message || '';
+            status.classList.toggle('is-error', Boolean(isError));
+        };
+
+        const setUploading = (isUploading) => {
+            container.classList.toggle('is-uploading', isUploading);
+            uploadButton.disabled = isUploading;
+            removeButton.disabled = isUploading || !customHiddenInput.value;
+        };
+
+        const applyValue = (attachment) => {
+            const id = attachment && attachment.id ? parseInt(attachment.id, 10) : 0;
+            const value = id > 0 ? String(id) : '';
+            const previewUrl =
+                (attachment && attachment.url) ||
+                (attachment && attachment.fullUrl) ||
+                '';
+            const altText = (attachment && attachment.alt) || '';
+
+            customHiddenInput.value = value;
+
+            if (acfValueInput) {
+                acfValueInput.value = value;
+                acfValueInput.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+
+            if (acfIdInput) {
+                acfIdInput.value = value;
+            }
+
+            if (acfUrlInput) {
+                acfUrlInput.value = previewUrl;
+            }
+
+            if (acfAltInput) {
+                acfAltInput.value = altText;
+            }
+
+            setPreview(previewUrl);
+            container.classList.toggle('has-image', Boolean(value));
+            removeButton.disabled = !value || container.classList.contains('is-uploading');
+        };
+
+        const getDefaultError = () =>
+            (settings.strings && settings.strings.error) || 'Upload failed.';
+
+        const validateFile = (file) => {
+            if (!file) {
+                return { valid: false, message: '' };
+            }
+
+            if (settings.maxFileSize && file.size && file.size > settings.maxFileSize) {
+                return {
+                    valid: false,
+                    message:
+                        (settings.strings && settings.strings.tooBig) ||
+                        getDefaultError(),
+                };
+            }
+
+            if (file.type && file.type.indexOf('image/') === 0) {
+                return { valid: true };
+            }
+
+            if (!allowedExtensions.length) {
+                return { valid: true };
+            }
+
+            const name = file.name ? file.name.toLowerCase() : '';
+            const match = name.match(/\.([a-z0-9]+)$/);
+
+            if (!match) {
+                return {
+                    valid: false,
+                    message:
+                        (settings.strings && settings.strings.invalidType) ||
+                        getDefaultError(),
+                };
+            }
+
+            if (allowedExtensions.indexOf(match[1]) === -1) {
+                return {
+                    valid: false,
+                    message:
+                        (settings.strings && settings.strings.invalidType) ||
+                        getDefaultError(),
+                };
+            }
+
+            return { valid: true };
+        };
+
+        uploadButton.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        removeButton.addEventListener('click', () => {
+            if (!customHiddenInput.value || container.classList.contains('is-uploading')) {
+                return;
+            }
+
+            applyValue({});
+            setStatus(
+                (settings.strings && settings.strings.removeSuccess) || '',
+                false
+            );
+        });
+
+        fileInput.addEventListener('change', () => {
+            const file = fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
+
+            if (!file) {
+                return;
+            }
+
+            const validation = validateFile(file);
+
+            if (!validation.valid) {
+                setStatus(validation.message, true);
+                fileInput.value = '';
+                return;
+            }
+
+            setStatus((settings.strings && settings.strings.uploading) || '', false);
+            setUploading(true);
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            fetch(settings.restUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'X-WP-Nonce': settings.nonce || '',
+                },
+                body: formData,
+            })
+                .then(async (response) => {
+                    let payload = null;
+
+                    try {
+                        payload = await response.json();
+                    } catch (error) {
+                        // Ignore JSON parse errors; handled below.
+                    }
+
+                    if (!response.ok) {
+                        const message =
+                            (payload && payload.message) || getDefaultError();
+                        throw new Error(message);
+                    }
+
+                    return payload;
+                })
+                .then((payload) => {
+                    applyValue(payload || {});
+                    setStatus(
+                        (settings.strings && settings.strings.success) || '',
+                        false
+                    );
+                })
+                .catch((error) => {
+                    setStatus(error.message || getDefaultError(), true);
+                })
+                .finally(() => {
+                    setUploading(false);
+                    fileInput.value = '';
+                });
+        });
+
+        applyValue(settings.current || {});
+        setStatus('', false);
+    });
+})();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.118
+Stable tag: 0.0.119
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.119 =
+* Replace the ACF media library interface with a streamlined, front-end profile photo uploader that stores uploads directly in the profile picture field.
+* Bump version to 0.0.119.
 
 = 0.0.118 =
 * Allow graduate-facing roles to complete asynchronous media uploads so profile photo updates succeed.


### PR DESCRIPTION
## Summary
- add a REST endpoint and localized assets that power a custom profile picture uploader
- enqueue the uploader on graduate and admin profile forms and bump the plugin version

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8576469c83278d7aab7acbf4effa