### PR TITLE
Improve profile picture uploader MIME handling and Greek text

### DIFF
--- a/assets/js/profile-picture-uploader.js
+++ b/assets/js/profile-picture-uploader.js
@@ -65,13 +65,15 @@
         uploadButton.type = 'button';
         uploadButton.className = 'button pspa-profile-picture-upload';
         uploadButton.textContent =
-            (settings.strings && settings.strings.upload) || 'Upload';
+            (settings.strings && settings.strings.upload) ||
+            'Επιλογή εικόνας';
 
         const removeButton = document.createElement('button');
         removeButton.type = 'button';
         removeButton.className = 'button pspa-profile-picture-remove';
         removeButton.textContent =
-            (settings.strings && settings.strings.remove) || 'Remove';
+            (settings.strings && settings.strings.remove) ||
+            'Αφαίρεση εικόνας';
 
         const status = document.createElement('p');
         status.className = 'pspa-profile-picture-status';
@@ -165,7 +167,8 @@
         };
 
         const getDefaultError = () =>
-            (settings.strings && settings.strings.error) || 'Upload failed.';
+            (settings.strings && settings.strings.error) ||
+            'Η μεταφόρτωση απέτυχε.';
 
         const validateFile = (file) => {
             if (!file) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.119
+Stable tag: 0.0.120
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.120 =
+* Allow the profile picture uploader to accept additional modern image formats, including WebP, HEIC and AVIF.
+* Translate the custom uploader interface text to Greek so the on-screen messaging matches the site's language.
+* Bump version to 0.0.120.
 
 = 0.0.119 =
 * Replace the ACF media library interface with a streamlined, front-end profile photo uploader that stores uploads directly in the profile picture field.


### PR DESCRIPTION
## Summary
- allow the custom profile picture uploader to recognise modern image MIME types and fall back to additional detection before rejecting files
- translate the uploader interface strings to Greek and adjust default messaging in the JavaScript widget
- bump the plugin version to 0.0.120 and document the change in the changelog

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cd89f4b0d88327b7f9d4c72a75d208