### PR TITLE
Add fallback avatar to profile photo uploader

### DIFF
--- a/assets/css/profile-picture-uploader.css
+++ b/assets/css/profile-picture-uploader.css
@@ -18,7 +18,7 @@
     position: relative;
     width: 128px;
     height: 128px;
-    border-radius: 50%;
+    border-radius: 0;
     overflow: hidden;
     background: #f1f3f6;
     display: flex;
@@ -32,14 +32,6 @@
     object-fit: cover;
 }
 
-.pspa-profile-picture-placeholder {
-    display: block;
-    text-align: center;
-    font-size: 0.875rem;
-    color: #6c757d;
-    padding: 0 0.5rem;
-}
-
 .pspa-profile-picture-controls {
     display: flex;
     flex-direction: column;
@@ -48,7 +40,8 @@
 }
 
 .pspa-profile-picture-controls .button {
-    align-self: flex-start;
+    width: 100%;
+    text-align: center;
 }
 
 .pspa-profile-picture-remove {

--- a/assets/js/profile-picture-uploader.js
+++ b/assets/js/profile-picture-uploader.js
@@ -46,17 +46,21 @@
         previewWrapper.className = 'pspa-profile-picture-preview';
 
         const previewImage = document.createElement('img');
-        previewImage.className = 'pspa-profile-picture-image';
-        previewImage.alt = '';
-        previewImage.setAttribute('hidden', 'hidden');
-
-        const placeholder = document.createElement('span');
-        placeholder.className = 'pspa-profile-picture-placeholder';
-        placeholder.textContent =
+        const fallbackImage =
+            (settings && settings.defaultImage) || '';
+        const placeholderText =
             (settings.strings && settings.strings.placeholder) || '';
 
+        previewImage.className = 'pspa-profile-picture-image';
+        previewImage.alt = placeholderText;
+
+        if (fallbackImage) {
+            previewImage.src = fallbackImage;
+        } else {
+            previewImage.setAttribute('hidden', 'hidden');
+        }
+
         previewWrapper.appendChild(previewImage);
-        previewWrapper.appendChild(placeholder);
 
         const controls = document.createElement('div');
         controls.className = 'pspa-profile-picture-controls';
@@ -111,14 +115,16 @@
         }
 
         const setPreview = (url) => {
-            if (url) {
-                previewImage.src = url;
+            const effectiveUrl = url || fallbackImage;
+
+            if (effectiveUrl) {
+                if (previewImage.getAttribute('src') !== effectiveUrl) {
+                    previewImage.src = effectiveUrl;
+                }
                 previewImage.removeAttribute('hidden');
-                placeholder.setAttribute('hidden', 'hidden');
             } else {
                 previewImage.removeAttribute('src');
                 previewImage.setAttribute('hidden', 'hidden');
-                placeholder.removeAttribute('hidden');
             }
         };
 
@@ -161,6 +167,7 @@
                 acfAltInput.value = altText;
             }
 
+            previewImage.alt = altText || placeholderText;
             setPreview(previewUrl);
             container.classList.toggle('has-image', Boolean(value));
             removeButton.disabled = !value || container.classList.contains('is-uploading');

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.120
+ * Version: 0.0.121
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.120' );
+define( 'PSPA_MS_VERSION', '0.0.121' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -806,6 +806,7 @@ function pspa_ms_enqueue_profile_picture_assets( $user_id ) {
         'maxFileSize'         => $max_upload_size,
         'maxFileSizeReadable' => $max_size_label,
         'allowedExtensions'   => $allowed_exts,
+        'defaultImage'        => esc_url_raw( 'https://new.pspa.gr/wp-content/uploads/2025/09/icon-7797704_1280-1.png' ),
         'current'             => array(
             'id'      => $current_id,
             'url'     => $preview_url ? $preview_url : ( $full_url ? $full_url : '' ),

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.120
+Stable tag: 0.0.121
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.121 =
+* Display the fallback PSPA avatar when no profile photo has been uploaded and remove the placeholder text block.
+* Show the profile photo preview as a square tile and keep the uploader buttons the same width.
+* Bump version to 0.0.121.
 
 = 0.0.120 =
 * Allow the profile picture uploader to accept additional modern image formats, including WebP, HEIC and AVIF.


### PR DESCRIPTION
## Summary
- display the provided PSPA placeholder graphic when no profile photo has been uploaded and remove the visible placeholder text
- show the profile photo preview as a square and make the uploader buttons share a consistent width
- expose the fallback URL to the front end and bump the plugin and readme versions to 0.0.121

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd8e34b468832793b6f7a1448701ce