### PR TITLE
Reverse LinkedIn profile gradient and bump version

### DIFF
--- a/assets/css/graduate-profile.css
+++ b/assets/css/graduate-profile.css
@@ -12,7 +12,7 @@
     align-items: center;
     gap: 1.5rem;
     padding: 2rem;
-    background: linear-gradient(135deg, var(--ink, #3b2b22), var(--card, #fffaf5));
+    background: linear-gradient(135deg, var(--card, #fffaf5), var(--ink, #3b2b22));
     color: #fff;
 }
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.121
+ * Version: 0.0.122
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.121' );
+define( 'PSPA_MS_VERSION', '0.0.122' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.121
+Stable tag: 0.0.122
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.122 =
+* Reverse the LinkedIn-style profile header gradient so the light tone leads into the dark accent.
+* Bump version to 0.0.122.
 
 = 0.0.121 =
 * Display the fallback PSPA avatar when no profile photo has been uploaded and remove the placeholder text block.


### PR DESCRIPTION
## Summary
- reverse the LinkedIn-style profile header gradient so the light tone leads into the dark accent
- bump the plugin version constant and readme stable tag to 0.0.122 with a matching changelog entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd983ae2308327b1c2157860dbc5a1