### PR TITLE
Show graduation year on public profile header

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.122
+ * Version: 0.0.123
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.122' );
+define( 'PSPA_MS_VERSION', '0.0.123' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.122
+Stable tag: 0.0.123
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.123 =
+* Display the graduation year in the public profile header instead of the city.
+* Bump version to 0.0.123.
 
 = 0.0.122 =
 * Reverse the LinkedIn-style profile header gradient so the light tone leads into the dark accent.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -42,7 +42,7 @@ $user_key  = 'user_' . $uid;
 $visibility = function_exists( 'get_field' ) ? get_field( 'gn_visibility_mode', $user_key ) : get_user_meta( $uid, 'gn_visibility_mode', true );
 
 $fields             = function_exists( 'acf_get_fields' ) ? acf_get_fields( 'group_gn_graduate_profile' ) : array();
-$header_field_names = array( 'gn_profile_picture', 'gn_first_name', 'gn_surname', 'gn_job_title', 'gn_position_company', 'gn_city', 'gn_country' );
+$header_field_names = array( 'gn_profile_picture', 'gn_first_name', 'gn_surname', 'gn_job_title', 'gn_position_company', 'gn_graduation_year', 'gn_country' );
 $header             = array( 'picture' => '', 'name' => array(), 'headline' => array(), 'location' => array() );
 $hide_catalogue_fields = function_exists( 'pspa_ms_current_user_is_professional_catalogue' ) && pspa_ms_current_user_is_professional_catalogue();
 $catalogue_hidden_fields = $hide_catalogue_fields && function_exists( 'pspa_ms_get_professional_catalogue_hidden_fields' )
@@ -109,7 +109,7 @@ foreach ( $header_field_names as $name ) {
                 $header['headline'][] = $value;
             }
             break;
-        case 'gn_city':
+        case 'gn_graduation_year':
         case 'gn_country':
             if ( $value ) {
                 $header['location'][] = $value;


### PR DESCRIPTION
## Summary
- show the graduation year in the public graduate profile header instead of the city while keeping other header details intact
- bump the plugin version metadata and changelog to 0.0.123

## Testing
- php -l templates/graduate-public-profile.php
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cd999daa208327a023d1ac7851055c