### PR TITLE
Limit graduate finder cards to contact essentials

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -53,6 +53,21 @@
     width: 100%;
 }
 
+.pspa-graduate-card--finder .pspa-graduate-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0.2em 0;
+}
+
+.pspa-graduate-card--finder .pspa-graduate-meta-label {
+    font-weight: 600;
+}
+
+.pspa-graduate-card--finder .pspa-graduate-meta-value {
+    word-break: break-word;
+}
+
 .pspa-finder-pagination {
     display: flex;
     justify-content: center;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.123
+Stable tag: 0.0.124
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.124 =
+* Simplify graduate finder cards so they only show the profile photo, name, graduation year and contact numbers while keeping the "Δείτε Περισσότερα" action.
+* Surface mobile and primary phone numbers in graduate finder results using the existing dashboard layout.
+* Bump version to 0.0.124.
 
 = 0.0.123 =
 * Display the graduation year in the public profile header instead of the city.


### PR DESCRIPTION
## Summary
- show only the profile picture, name, graduation year and contact numbers on graduate finder cards while keeping the existing layout actions
- add finder-specific styling for the compact meta rows
- bump the plugin version to 0.0.124 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cda64a77ac8327b64932e9395b1a77