### PR TITLE
Limit graduate finder profile view to essentials

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.124
+ * Version: 0.0.125
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.124' );
+define( 'PSPA_MS_VERSION', '0.0.125' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -525,6 +525,7 @@ add_action( 'init', 'pspa_ms_register_public_profile_route' );
  */
 function pspa_ms_public_profile_query_vars( $vars ) {
     $vars[] = 'pspa_graduate';
+    $vars[] = 'pspa_profile_view';
     return $vars;
 }
 add_filter( 'query_vars', 'pspa_ms_public_profile_query_vars' );
@@ -2328,6 +2329,9 @@ function pspa_ms_render_graduate_finder_card( $user_id ) {
     }
 
     $profile_url  = pspa_ms_get_public_profile_url( $user_id );
+    if ( $profile_url ) {
+        $profile_url = add_query_arg( 'pspa_profile_view', 'finder', $profile_url );
+    }
     $current_user = wp_get_current_user();
     $can_edit     = current_user_can( 'manage_options' ) ||
         in_array( 'system-admin', (array) $current_user->roles, true ) ||

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.124
+Stable tag: 0.0.125
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.125 =
+* Route graduate finder "Δείτε Περισσότερα" links to a trimmed profile view that only surfaces the photo, name, graduation year, email and mobile number while keeping the LinkedIn-style layout.
+* Keep graduate directory cards displaying the graduate's job information and leave the full public profile untouched.
+* Bump version to 0.0.125.
 
 = 0.0.124 =
 * Simplify graduate finder cards so they only show the profile photo, name, graduation year and contact numbers while keeping the "Δείτε Περισσότερα" action.


### PR DESCRIPTION
## Summary
- add a query var and update graduate finder cards so their "Δείτε Περισσότερα" links open a dedicated trimmed profile view
- adjust the public profile template to show only the approved basics for the finder view while leaving the full directory layout untouched
- bump the plugin version to 0.0.125 and document the change

## Testing
- php -l pspa-membership-system.php
- php -l templates/graduate-public-profile.php

------
https://chatgpt.com/codex/tasks/task_e_68cdad1943208327b7f709c4cd83b73a