### PR TITLE
Simplify graduate finder results

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -51,6 +51,24 @@
 
 .pspa-graduate-card--finder {
     width: 100%;
+    align-items: center;
+}
+
+.pspa-graduate-card--finder .pspa-graduate-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    justify-content: center;
+}
+
+.pspa-graduate-card--finder .pspa-graduate-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.pspa-graduate-card--finder .pspa-graduate-link:focus,
+.pspa-graduate-card--finder .pspa-graduate-link:hover {
+    text-decoration: underline;
 }
 
 .pspa-graduate-card--finder .pspa-graduate-meta {

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.125
+ * Version: 0.0.126
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.125' );
+define( 'PSPA_MS_VERSION', '0.0.126' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -2315,30 +2315,10 @@ function pspa_ms_render_graduate_finder_card( $user_id ) {
     }
 
     $graduation_year = $fetch_field( 'gn_graduation_year' );
-    $mobile          = $fetch_field( 'gn_mobile' );
 
-    $phone_keys = array( 'gn_work_phone', 'gn_home_phone', 'gn_work_phone_2', 'gn_home_phone_2' );
-    $phone      = '';
-
-    foreach ( $phone_keys as $phone_key ) {
-        $value = $fetch_field( $phone_key );
-        if ( '' !== $value ) {
-            $phone = $value;
-            break;
-        }
-    }
-
-    $profile_url  = pspa_ms_get_public_profile_url( $user_id );
+    $profile_url = pspa_ms_get_public_profile_url( $user_id );
     if ( $profile_url ) {
         $profile_url = add_query_arg( 'pspa_profile_view', 'finder', $profile_url );
-    }
-    $current_user = wp_get_current_user();
-    $can_edit     = current_user_can( 'manage_options' ) ||
-        in_array( 'system-admin', (array) $current_user->roles, true ) ||
-        in_array( 'sysadmin', (array) $current_user->roles, true );
-
-    if ( $can_edit ) {
-        $edit_url = add_query_arg( 'edit_user', $user_id, pspa_ms_get_graduate_profile_edit_url() );
     }
 
     $card_classes = array( 'pspa-graduate-card', 'pspa-graduate-card--finder' );
@@ -2346,33 +2326,27 @@ function pspa_ms_render_graduate_finder_card( $user_id ) {
     ob_start();
     ?>
     <div class="<?php echo esc_attr( implode( ' ', array_unique( $card_classes ) ) ); ?>">
-        <div class="pspa-graduate-avatar"><?php echo get_avatar( $user_id, 96 ); ?></div>
+        <div class="pspa-graduate-avatar">
+            <?php if ( $profile_url ) : ?>
+                <a class="pspa-graduate-link" href="<?php echo esc_url( $profile_url ); ?>"><?php echo get_avatar( $user_id, 96 ); ?></a>
+            <?php else : ?>
+                <?php echo get_avatar( $user_id, 96 ); ?>
+            <?php endif; ?>
+        </div>
         <div class="pspa-graduate-details">
-            <h3 class="pspa-graduate-name"><?php echo esc_html( $name ); ?></h3>
+            <h3 class="pspa-graduate-name">
+                <?php if ( $profile_url ) : ?>
+                    <a class="pspa-graduate-link" href="<?php echo esc_url( $profile_url ); ?>"><?php echo esc_html( $name ); ?></a>
+                <?php else : ?>
+                    <?php echo esc_html( $name ); ?>
+                <?php endif; ?>
+            </h3>
             <?php if ( $graduation_year ) : ?>
                 <p class="pspa-graduate-meta pspa-graduate-meta--year">
                     <span class="pspa-graduate-meta-label"><?php esc_html_e( 'Έτος Αποφοίτησης:', 'pspa-membership-system' ); ?></span>
                     <span class="pspa-graduate-meta-value"><?php echo esc_html( $graduation_year ); ?></span>
                 </p>
             <?php endif; ?>
-            <?php if ( $mobile ) : ?>
-                <p class="pspa-graduate-meta pspa-graduate-meta--mobile">
-                    <span class="pspa-graduate-meta-label"><?php esc_html_e( 'Κινητό:', 'pspa-membership-system' ); ?></span>
-                    <span class="pspa-graduate-meta-value"><?php echo esc_html( $mobile ); ?></span>
-                </p>
-            <?php endif; ?>
-            <?php if ( $phone ) : ?>
-                <p class="pspa-graduate-meta pspa-graduate-meta--phone">
-                    <span class="pspa-graduate-meta-label"><?php esc_html_e( 'Τηλέφωνο:', 'pspa-membership-system' ); ?></span>
-                    <span class="pspa-graduate-meta-value"><?php echo esc_html( $phone ); ?></span>
-                </p>
-            <?php endif; ?>
-            <div class="pspa-graduate-actions">
-                <a class="pspa-graduate-more et_pb_button" href="<?php echo esc_url( $profile_url ); ?>"><?php esc_html_e( 'Δείτε Περισσότερα', 'pspa-membership-system' ); ?></a>
-                <?php if ( $can_edit ) : ?>
-                    <a class="pspa-graduate-edit et_pb_button" href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Επεξεργασία', 'pspa-membership-system' ); ?></a>
-                <?php endif; ?>
-            </div>
         </div>
     </div>
     <?php

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.125
+Stable tag: 0.0.126
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.126 =
+* Limit graduate finder cards to the profile photo, first name, last name and graduation year while retaining profile links.
+* Bump version to 0.0.126.
 
 = 0.0.125 =
 * Route graduate finder "Δείτε Περισσότερα" links to a trimmed profile view that only surfaces the photo, name, graduation year, email and mobile number while keeping the LinkedIn-style layout.


### PR DESCRIPTION
## Summary
- limit graduate finder cards to the avatar, name and graduation year while keeping profile links available
- update finder styling and documentation for version 0.0.126

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb1caac108327bec96094ed5dfb30