### PR TITLE
Display home phone on finder profile view

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.127
+ * Version: 0.0.128
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.127' );
+define( 'PSPA_MS_VERSION', '0.0.128' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.127
+Stable tag: 0.0.128
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.128 =
+* Display the graduate home phone number on trimmed finder profile views when permitted by the visibility toggles.
+* Bump version to 0.0.128.
 
 = 0.0.127 =
 * Restore graduate finder card action buttons while keeping the avatar and name linked to the trimmed public profile view.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -170,10 +170,12 @@ $get_scalar_field_value = static function ( $field_name ) use ( $can_display_fie
 $finder_graduation_year = '';
 $finder_email           = '';
 $finder_mobile          = '';
+$finder_home_phone      = '';
 
 if ( $is_finder_view ) {
     $finder_graduation_year = $get_scalar_field_value( 'gn_graduation_year' );
     $finder_mobile          = $get_scalar_field_value( 'gn_mobile' );
+    $finder_home_phone      = $get_scalar_field_value( 'gn_home_phone' );
 
     if ( $can_display_field( 'gn_email' ) ) {
         $email_value = $get_raw_field_value( 'gn_email' );
@@ -208,13 +210,19 @@ if ( $is_finder_view ) {
         </div>
     </div>
     <?php if ( $is_finder_view ) : ?>
-        <?php if ( $finder_graduation_year || $finder_email || $finder_mobile ) : ?>
+        <?php if ( $finder_graduation_year || $finder_email || $finder_mobile || $finder_home_phone ) : ?>
             <div class="profile-section profile-section--finder">
                 <div class="profile-fields">
                     <?php if ( $finder_graduation_year ) : ?>
                         <div class="profile-field profile-field-gn_graduation_year">
                             <span class="label"><?php esc_html_e( 'Έτος Αποφοίτησης', 'pspa-membership-system' ); ?></span>
                             <span class="value"><?php echo esc_html( $finder_graduation_year ); ?></span>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ( $finder_home_phone ) : ?>
+                        <div class="profile-field profile-field-gn_home_phone">
+                            <span class="label"><?php esc_html_e( 'Τηλ. Κατοικίας', 'pspa-membership-system' ); ?></span>
+                            <span class="value"><?php echo esc_html( $finder_home_phone ); ?></span>
                         </div>
                     <?php endif; ?>
                     <?php if ( $finder_email ) : ?>


### PR DESCRIPTION
## Summary
- surface the graduate home phone number on the trimmed finder profile view when visibility allows it
- bump the plugin version and changelog to 0.0.128

## Testing
- php -l templates/graduate-public-profile.php
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbae865e48327a35d6a1fdcf2dfcf