### PR TITLE
Fix finder profile view 404 for hidden graduates

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.129
+ * Version: 0.0.130
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.129' );
+define( 'PSPA_MS_VERSION', '0.0.130' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.129
+Stable tag: 0.0.130
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.130 =
+* Fix trimmed graduate finder profile views returning 404 when directory visibility is disabled.
+* Bump version to 0.0.130.
 
 = 0.0.129 =
 * Include professional catalogue members in graduate finder results even when their directory visibility toggle is off.

--- a/templates/graduate-public-profile.php
+++ b/templates/graduate-public-profile.php
@@ -21,16 +21,27 @@ $can_view_hidden = function_exists( 'pspa_ms_current_user_can_manage_directory_v
     ? pspa_ms_current_user_can_manage_directory_visibility()
     : current_user_can( 'manage_options' );
 
-if (
-    ! $pspa_user instanceof WP_User ||
-    ( ! $can_view_hidden && function_exists( 'pspa_ms_user_is_visible_in_directory' ) && ! pspa_ms_user_is_visible_in_directory( $pspa_user->ID ) )
-) {
+$render_not_found = static function () {
     if ( ! headers_sent() ) {
         status_header( 404 );
     }
     get_header();
     echo '<div class="pspa-dashboard"><p>' . esc_html__( 'Ο απόφοιτος δεν βρέθηκε.', 'pspa-membership-system' ) . '</p></div>';
     get_footer();
+};
+
+if ( ! $pspa_user instanceof WP_User ) {
+    $render_not_found();
+    return;
+}
+
+$is_directory_visible = true;
+if ( function_exists( 'pspa_ms_user_is_visible_in_directory' ) ) {
+    $is_directory_visible = (bool) pspa_ms_user_is_visible_in_directory( $pspa_user->ID );
+}
+
+if ( ! $can_view_hidden && ! $is_directory_visible && ! $is_finder_view ) {
+    $render_not_found();
     return;
 }
 


### PR DESCRIPTION
## Summary
- allow the trimmed finder public profile view to load even when the graduate is hidden from the directory so finder links no longer 404
- reuse a shared helper when returning the graduate not found response
- bump the plugin version to 0.0.130 and document the release

## Testing
- php -l pspa-membership-system.php
- php -l templates/graduate-public-profile.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbe44b0fc8327aaf239fa48a2e135