### PR TITLE
Fix finder view access for Professional Catalogue users

### DIFF
--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.130
+ * Version: 0.0.131
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.130' );
+define( 'PSPA_MS_VERSION', '0.0.131' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -543,7 +543,18 @@ function pspa_ms_public_profile_template( $template ) {
         if ( ! $user ) {
             return get_404_template();
         }
-        if ( ! pspa_ms_user_is_visible_in_directory( $user->ID ) && ! pspa_ms_current_user_can_manage_directory_visibility() ) {
+        $profile_view = get_query_var( 'pspa_profile_view' );
+        if ( ! is_string( $profile_view ) ) {
+            $profile_view = '';
+        }
+        $profile_view    = sanitize_key( $profile_view );
+        $can_view_hidden = pspa_ms_current_user_can_manage_directory_visibility();
+
+        if ( ! $can_view_hidden && 'finder' === $profile_view && pspa_ms_current_user_is_professional_catalogue() ) {
+            $can_view_hidden = true;
+        }
+
+        if ( ! pspa_ms_user_is_visible_in_directory( $user->ID ) && ! $can_view_hidden ) {
             return get_404_template();
         }
         set_query_var( 'pspa_graduate_user', $user );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.130
+Stable tag: 0.0.131
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.131 =
+* Allow Professional Catalogue finder views to load hidden graduate profiles instead of returning 404 errors.
+* Bump version to 0.0.131.
 
 = 0.0.130 =
 * Fix trimmed graduate finder profile views returning 404 when directory visibility is disabled.


### PR DESCRIPTION
## Summary
- allow Professional Catalogue users to view hidden graduate profiles when explicitly loading the finder view
- sanitize the finder view query var and reuse the visibility bypass when routing to the public profile template
- bump the plugin version to 0.0.131 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc0e02c9c8327b9fd4acf94eb6301