### PR TITLE
Prevent Graduate Finder abort errors and add loading spinner

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -36,13 +36,38 @@
     outline-offset: 1px;
 }
 
+
 .pspa-graduate-finder__results {
     display: grid;
     gap: 1rem;
+    position: relative;
+    min-height: 3.5rem;
 }
 
 .pspa-graduate-finder__results.is-loading {
     opacity: 0.6;
+}
+
+.pspa-graduate-finder__results::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    margin: -1.25rem 0 0 -1.25rem;
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0.2);
+    border-top-color: var(--ink, #3b2b22);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 2;
+}
+
+.pspa-graduate-finder__results.is-loading::after {
+    opacity: 1;
+    animation: pspa-ms-spinner 0.75s linear infinite;
 }
 
 .pspa-graduate-finder__results .pspa-graduate-card {
@@ -101,4 +126,14 @@
 
 .pspa-finder-pagination .current {
     font-weight: 600;
+}
+
+@keyframes pspa-ms-spinner {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
 }

--- a/assets/js/graduate-finder.js
+++ b/assets/js/graduate-finder.js
@@ -9,6 +9,15 @@ jQuery(function($){
         var $results = $container.find('.pspa-graduate-finder__results');
         var currentPage = 1;
         var request = null;
+        var requestToken = 0;
+
+        function setBusy(isBusy){
+            if (isBusy) {
+                $results.addClass('is-loading').attr('aria-busy', 'true');
+            } else {
+                $results.removeClass('is-loading').removeAttr('aria-busy');
+            }
+        }
 
         function fetchResults(){
             if (request && request.readyState !== 4) {
@@ -24,7 +33,10 @@ jQuery(function($){
                 graduation_year: $form.find('[name="graduation_year"]').val()
             };
 
-            $results.addClass('is-loading');
+            requestToken += 1;
+            var activeToken = requestToken;
+
+            setBusy(true);
 
             request = $.post(pspaMsFinder.ajaxUrl, data)
                 .done(function(response){
@@ -34,14 +46,19 @@ jQuery(function($){
                         $results.html('<p>' + pspaMsFinder.errorMessage + '</p>');
                     }
                 })
-                .fail(function(){
+                .fail(function(jqXHR, textStatus){
+                    if (textStatus === 'abort') {
+                        return;
+                    }
                     if (pspaMsFinder.errorMessage) {
                         $results.html('<p>' + pspaMsFinder.errorMessage + '</p>');
                     }
                 })
                 .always(function(){
-                    $results.removeClass('is-loading');
-                    request = null;
+                    if (activeToken === requestToken) {
+                        setBusy(false);
+                        request = null;
+                    }
                 });
         }
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.131
+ * Version: 0.0.132
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.131' );
+define( 'PSPA_MS_VERSION', '0.0.132' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );
@@ -2425,7 +2425,7 @@ function pspa_ms_graduate_finder_shortcode() {
                 <input type="text" id="<?php echo esc_attr( $form_id ); ?>-year" name="graduation_year" placeholder="<?php esc_attr_e( 'Έτος Αποφοίτησης', 'pspa-membership-system' ); ?>" inputmode="numeric" autocomplete="off" />
             </label>
         </form>
-        <div id="<?php echo esc_attr( $results_id ); ?>" class="pspa-graduate-finder__results">
+        <div id="<?php echo esc_attr( $results_id ); ?>" class="pspa-graduate-finder__results" role="status" aria-live="polite">
             <p class="pspa-graduate-finder__status"><?php esc_html_e( 'Φόρτωση...', 'pspa-membership-system' ); ?></p>
         </div>
     </div>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.131
+Stable tag: 0.0.132
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,11 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.132 =
+* Prevent Graduate Finder requests from showing the generic error message when earlier searches are aborted while typing.
+* Display a loading spinner while Graduate Finder results refresh.
+* Bump version to 0.0.132.
 
 = 0.0.131 =
 * Allow Professional Catalogue finder views to load hidden graduate profiles instead of returning 404 errors.


### PR DESCRIPTION
## Summary
- avoid showing the generic error message when Graduate Finder AJAX requests are aborted mid-typing
- add accessibility hooks and a CSS spinner so finder results indicate when new data is loading
- bump the plugin version to 0.0.132 and document the changes

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc397e33c8327a339e0364646fe3d