### PR TITLE
Move graduate finder spinner under filters

### DIFF
--- a/assets/css/graduate-finder.css
+++ b/assets/css/graduate-finder.css
@@ -46,16 +46,17 @@
 
 .pspa-graduate-finder__results.is-loading {
     opacity: 0.6;
+    padding-top: 3.75rem;
 }
 
 .pspa-graduate-finder__results::after {
     content: '';
     position: absolute;
-    top: 50%;
+    top: 0.75rem;
     left: 50%;
+    transform: translateX(-50%);
     width: 2.5rem;
     height: 2.5rem;
-    margin: -1.25rem 0 0 -1.25rem;
     border-radius: 50%;
     border: 3px solid rgba(0, 0, 0, 0.2);
     border-top-color: var(--ink, #3b2b22);

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.132
+ * Version: 0.0.133
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.132' );
+define( 'PSPA_MS_VERSION', '0.0.133' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.132
+Stable tag: 0.0.133
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.133 =
+* Position the Graduate Finder loading spinner directly under the filters so it stays visible even when long result lists scroll off-screen.
+* Bump version to 0.0.133.
 
 = 0.0.132 =
 * Prevent Graduate Finder requests from showing the generic error message when earlier searches are aborted while typing.


### PR DESCRIPTION
## Summary
- move the Graduate Finder loading indicator directly beneath the filter form so it remains visible even when results extend down the page
- add top padding while loading to give the spinner dedicated space above the cards
- bump the plugin version to 0.0.133 and update the readme entry

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc65c103c83278d187e09ab4f1f61