### PR TITLE
Use graduate profile picture for avatars

### DIFF
--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -27,6 +27,15 @@
 
 .pspa-graduate-avatar {
     margin-right: 1em;
+    flex-shrink: 0;
+}
+
+.pspa-graduate-avatar img {
+    display: block;
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
 }
 
 .pspa-graduate-details h3 {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.133
+Stable tag: 0.0.134
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.134 =
+* Display graduate cards and finder results using the uploaded profile photo instead of the Gravatar image while keeping a crisp 96px avatar.
+* Bump version to 0.0.134.
 
 = 0.0.133 =
 * Position the Graduate Finder loading spinner directly under the filters so it stays visible even when long result lists scroll off-screen.


### PR DESCRIPTION
## Summary
- add a helper that loads the graduate ACF profile picture (respecting visibility toggles) for card avatars with a Gravatar fallback
- update the graduate directory and finder cards to reuse the helper and style the avatar so the uploaded image displays crisply at 96px
- bump the plugin version and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc93b61648327ad5aafd3d62898fc