### PR TITLE
Make graduate directory avatars square

### DIFF
--- a/assets/css/graduate-directory.css
+++ b/assets/css/graduate-directory.css
@@ -66,7 +66,7 @@
     display: block;
     width: 96px;
     height: 96px;
-    border-radius: 50%;
+    border-radius: 0;
     object-fit: cover;
 }
 

--- a/pspa-membership-system.php
+++ b/pspa-membership-system.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PSPA Membership System
  * Description: Membership system for PSPA.
- * Version: 0.0.135
+ * Version: 0.0.136
  * Author: George Nicolaou
  * Author URI: https://profiles.wordpress.org/orionaselite/
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'PSPA_MS_VERSION', '0.0.135' );
+define( 'PSPA_MS_VERSION', '0.0.136' );
 
 if ( ! defined( 'PSPA_MS_ENABLE_LOGGING' ) ) {
     define( 'PSPA_MS_ENABLE_LOGGING', defined( 'WP_DEBUG' ) && WP_DEBUG );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, woocommerce, acf, profile
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 0.0.135
+Stable tag: 0.0.136
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ The plugin registers two custom user roles:
 The plugin requires Advanced Custom Fields Pro, WooCommerce, and Advanced Access Manager.
 
 == Changelog ==
+
+= 0.0.136 =
+* Remove the circular border radius from graduate directory avatars so profile photos display with their natural corners.
+* Bump version to 0.0.136.
 
 = 0.0.135 =
 * Display the shared AJAX loader before graduate finder and directory results so it remains visible while lists refresh.


### PR DESCRIPTION
## Summary
- remove the circular border radius from graduate directory avatars so profile photos render with square corners
- bump the plugin version to 0.0.136 and document the change in the readme

## Testing
- php -l pspa-membership-system.php

------
https://chatgpt.com/codex/tasks/task_e_68cdcec8ac24832782a03633882a08ae